### PR TITLE
Add versioning to the C++ portion of the library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,22 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 project(svs
     LANGUAGES CXX
+    # The version is tested in the files:
+    # - /tests/svs/lib/version.cpp
+    # - /bindings/python/tests/test_common.py
+    # Manually keep in-sync with:
+    # - /bindings/python/setup.py
     VERSION 0.0.1
 )
 
 set(SVS_LIB svs_devel)
+
+# Version variables.
+set(SVS_VERSION ${PROJECT_VERSION})
+set(SVS_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(SVS_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(SVS_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
 add_library(${SVS_LIB} INTERFACE)
 set_target_properties(${SVS_LIB} PROPERTIES EXPORT_NAME svs)
 add_library(svs::svs ALIAS ${SVS_LIB})
@@ -21,6 +33,15 @@ target_include_directories(
 # We use C++ 20 features in our exposed headers.
 # Anyone using us as a depdency and including our headers will need to be C++20 compatible.
 target_compile_features(${SVS_LIB} INTERFACE cxx_std_20)
+
+# Populate with the version number macro.
+target_compile_options(
+    ${SVS_LIB}
+    INTERFACE
+    "-DSVS_VERSION_MAJOR=${SVS_VERSION_MAJOR}"
+    "-DSVS_VERSION_MINOR=${SVS_VERSION_MINOR}"
+    "-DSVS_VERSION_PATCH=${SVS_VERSION_PATCH}"
+)
 
 #####
 ##### Options and extra build steps
@@ -90,6 +111,8 @@ install(
 ##### Config File
 #####
 
+set(VERSION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/svsConfigVersion.cmake")
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/Config.cmake.in"
@@ -97,8 +120,16 @@ configure_package_config_file(
     INSTALL_DESTINATION "${LIB_CONFIG_INSTALL_DIR}"
 )
 
+# Don't make compatibility guarentees until we reach a compatibility milestone.
+write_basic_package_version_file(
+    ${VERSION_CONFIG}
+    VERSION ${SVS_VERSION}
+    COMPATIBILITY ExactVersion
+)
+
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/svsConfig.cmake"
+    "${VERSION_CONFIG}"
     DESTINATION "${LIB_CONFIG_INSTALL_DIR}"
 )
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.18) # keep in-sync with `pyproject.toml`
 project(pysvs)
 
-message("CMAKE VERSION: ${CMAKE_VERSION}")
-
 # Install pybind11 manually for version control.
 include(FetchContent)
 FetchContent_Declare(

--- a/bindings/python/src/python_bindings.cpp
+++ b/bindings/python/src/python_bindings.cpp
@@ -141,6 +141,11 @@ PYBIND11_MODULE(PYSVS_MODULE_NAME, m) {
     // "first class" in the top level `pysvs` module>
     auto name_override = ScopedModuleNameOverride(m, "pysvs");
     m.doc() = "Python bindings";
+    m.def(
+        "library_version",
+        []() { return svs::lib::svs_version.str(); },
+        "Obtain the version string of the backing C++ library."
+    );
 
     py::enum_<svs::DistanceType>(m, "DistanceType", "Select which distance function to use")
         .value("L2", svs::DistanceType::L2, "Euclidean Distance (minimize)")

--- a/bindings/python/tests/test_common.py
+++ b/bindings/python/tests/test_common.py
@@ -45,6 +45,9 @@ class CommonTester(unittest.TestCase):
     ##### Tests
     #####
 
+    def test_version(self):
+        self.assertEqual(pysvs.library_version(), "v0.0.1")
+
     def test_random_dataset(self):
         for dtype in (np.float32, np.uint32, np.uint8):
             x = pysvs.common.random_dataset(10000, 10, dtype = dtype, seed = 1234)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -118,6 +118,7 @@ target_compile_options(
         -Wno-parentheses # GCC in CI has issues without it
 )
 
+
 if(CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL RelWithDebugInfo)
     target_compile_options(svs_compile_options INTERFACE -O3)
 endif()

--- a/include/svs/lib/saveload.h
+++ b/include/svs/lib/saveload.h
@@ -15,6 +15,7 @@
 // file handling
 #include "svs/lib/exception.h"
 #include "svs/lib/file.h"
+#include "svs/lib/version.h"
 
 // third-party
 #include "svs/third-party/fmt.h"
@@ -28,125 +29,6 @@
 #include <string_view>
 
 namespace svs {
-namespace lib {
-
-///
-/// @brief Parse the provided view as a base-10 integer.
-///
-/// @tparam T The integer type to parse.
-///
-/// @param view The object to parse.
-///
-/// @returns The parsed integer.
-///
-/// @throws svs::ANNException if anything goes wrong during parsing.
-///
-template <std::integral T> [[nodiscard]] T parse_int(std::string_view view) {
-    auto value = T{0};
-    auto result = std::from_chars(view.begin(), view.end(), value);
-    if (result.ec != std::errc()) {
-        throw ANNEXCEPTION("Something went wrong with number parsing!");
-    }
-    return value;
-}
-
-///
-/// @brief A representation of the typical three-numbered version identifier.
-///
-/// The version numbers are expected to roughly follow semantic versioning.
-///
-/// * MAJOR versions are incremented when incompatible API changes are made.
-/// * MINOR versions are incremented when functionality is added in a backward compatible
-///     manner.
-/// * PATCH versions are for backwards compatible bug fixes.
-///
-/// In general, no guarentees are made with a version number "v0.0.x".
-/// Such items are experimental and should not be relied upon.
-///
-/// Version numbers "v0.x.y" represent actively changing APIs and should be used with care.
-///
-struct Version {
-    /// @brief Return the formatted version as "vMAJOR.MINOR.PATCH".
-    std::string str() const { return fmt::format("v{}.{}.{}", major, minor, patch); }
-
-    /// @brief Construct a new Version class.
-    constexpr explicit Version(size_t major, size_t minor, size_t patch)
-        : major{major}
-        , minor{minor}
-        , patch{patch} {}
-
-    ///
-    /// @brief Construct a new Version class by parsing a formatted string.
-    ///
-    /// @throws svs::ANNException if the string is malformed.
-    ///
-    /// The string to be formatted should be *exactly* in the form "vMAJOR.MINOR.PATCH"
-    /// where each of MAJOR, MINOR, and PATCH is a positive base-10 integer.
-    ///
-    explicit Version(std::string_view v) {
-        auto npos = v.npos;
-        if (!v.starts_with('v')) {
-            throw ANNEXCEPTION("Formatted version string doesn't begin with a 'v'!");
-        }
-
-        auto mallformed = []() { throw ANNEXCEPTION("Malformed version!"); };
-
-        size_t start = 1;
-        size_t stop = v.find('.', start);
-        if (stop == npos) {
-            mallformed();
-        }
-        major = parse_int<size_t>(v.substr(start, stop - start));
-
-        // Parse minor
-        start = stop + 1;
-        stop = v.find('.', start);
-        if (stop == npos) {
-            mallformed();
-        }
-        minor = parse_int<size_t>(v.substr(start, stop - start));
-        // parse to the end of the string.
-        patch = parse_int<size_t>(v.substr(stop + 1));
-    }
-
-    ///// Members
-    size_t major;
-    size_t minor;
-    size_t patch;
-};
-
-///
-/// @brief Compare two versions for equality.
-///
-/// Two versions are equal if all fields compare equal.
-///
-inline constexpr bool operator==(const Version& x, const Version& y) {
-    return (x.major == y.major) && (x.minor == y.minor) && (x.patch == y.patch);
-}
-
-/// @brief Compare two versions for a "less than" relationship.
-inline constexpr bool operator<(const Version& x, const Version& y) {
-    // Compare major.
-    if (x.major < y.major) {
-        return true;
-    } else if (x.major > y.major) {
-        return false;
-    }
-
-    // Major is equal -- compare minor.
-    if (x.minor < y.minor) {
-        return true;
-    } else if (x.minor > y.minor) {
-        return false;
-    }
-
-    // Minor is equal -- compare patch.
-    return x.patch < y.patch;
-}
-
-inline constexpr bool operator>(const Version& x, const Version& y) { return y < x; }
-
-} // namespace lib
 
 ///
 /// @brief Get the version from a TOML table.

--- a/include/svs/lib/version.h
+++ b/include/svs/lib/version.h
@@ -1,0 +1,151 @@
+/**
+ *    Copyright (C) 2023-present, Intel Corporation
+ *
+ *    You can redistribute and/or modify this software under the terms of the
+ *    GNU Affero General Public License version 3.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    version 3 along with this software. If not, see
+ *    <https://www.gnu.org/licenses/agpl-3.0.en.html>.
+ */
+
+// Version class and global library version.
+#pragma once
+
+// svs
+#include "svs/lib/exception.h"
+
+// third-party
+#include "svs/third-party/fmt.h"
+
+// stl
+#include <charconv>
+#include <string>
+#include <string_view>
+
+namespace svs::lib {
+
+///
+/// @brief Parse the provided view as a base-10 integer.
+///
+/// @tparam T The integer type to parse.
+///
+/// @param view The object to parse.
+///
+/// @returns The parsed integer.
+///
+/// @throws svs::ANNException if anything goes wrong during parsing.
+///
+template <std::integral T> [[nodiscard]] T parse_int(std::string_view view) {
+    auto value = T{0};
+    auto result = std::from_chars(view.begin(), view.end(), value);
+    if (result.ec != std::errc()) {
+        throw ANNEXCEPTION("Something went wrong with number parsing!");
+    }
+    return value;
+}
+
+///
+/// @brief A representation of the typical three-numbered version identifier.
+///
+/// The version numbers are expected to roughly follow semantic versioning.
+///
+/// * MAJOR versions are incremented when incompatible API changes are made.
+/// * MINOR versions are incremented when functionality is added in a backward compatible
+///     manner.
+/// * PATCH versions are for backwards compatible bug fixes.
+///
+/// In general, no guarentees are made with a version number "v0.0.x".
+/// Such items are experimental and should not be relied upon.
+///
+/// Version numbers "v0.x.y" represent actively changing APIs and should be used with care.
+///
+struct Version {
+    /// @brief Return the formatted version as "vMAJOR.MINOR.PATCH".
+    std::string str() const { return fmt::format("v{}.{}.{}", major, minor, patch); }
+
+    /// @brief Construct a new Version class.
+    constexpr explicit Version(size_t major, size_t minor, size_t patch)
+        : major{major}
+        , minor{minor}
+        , patch{patch} {}
+
+    ///
+    /// @brief Construct a new Version class by parsing a formatted string.
+    ///
+    /// @throws svs::ANNException if the string is malformed.
+    ///
+    /// The string to be formatted should be *exactly* in the form "vMAJOR.MINOR.PATCH"
+    /// where each of MAJOR, MINOR, and PATCH is a positive base-10 integer.
+    ///
+    explicit Version(std::string_view v) {
+        auto npos = v.npos;
+        if (!v.starts_with('v')) {
+            throw ANNEXCEPTION("Formatted version string doesn't begin with a 'v'!");
+        }
+
+        auto mallformed = []() { throw ANNEXCEPTION("Malformed version!"); };
+
+        size_t start = 1;
+        size_t stop = v.find('.', start);
+        if (stop == npos) {
+            mallformed();
+        }
+        major = parse_int<size_t>(v.substr(start, stop - start));
+
+        // Parse minor
+        start = stop + 1;
+        stop = v.find('.', start);
+        if (stop == npos) {
+            mallformed();
+        }
+        minor = parse_int<size_t>(v.substr(start, stop - start));
+        // parse to the end of the string.
+        patch = parse_int<size_t>(v.substr(stop + 1));
+    }
+
+    ///// Members
+    size_t major;
+    size_t minor;
+    size_t patch;
+};
+
+///
+/// @brief Compare two versions for equality.
+///
+/// Two versions are equal if all fields compare equal.
+///
+inline constexpr bool operator==(const Version& x, const Version& y) {
+    return (x.major == y.major) && (x.minor == y.minor) && (x.patch == y.patch);
+}
+
+/// @brief Compare two versions for a "less than" relationship.
+inline constexpr bool operator<(const Version& x, const Version& y) {
+    // Compare major.
+    if (x.major < y.major) {
+        return true;
+    } else if (x.major > y.major) {
+        return false;
+    }
+
+    // Major is equal -- compare minor.
+    if (x.minor < y.minor) {
+        return true;
+    } else if (x.minor > y.minor) {
+        return false;
+    }
+
+    // Minor is equal -- compare patch.
+    return x.patch < y.patch;
+}
+
+inline constexpr bool operator>(const Version& x, const Version& y) { return y < x; }
+
+///
+/// Global Library Version
+/// Macro-defines are established in the top level CMakeLists.txt.
+///
+inline constexpr Version svs_version =
+    Version(SVS_VERSION_MAJOR, SVS_VERSION_MINOR, SVS_VERSION_PATCH);
+
+} // namespace svs::lib

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/svs/lib/threads/thread.cpp
     ${TEST_DIR}/svs/lib/threads/threadlocal.cpp
     ${TEST_DIR}/svs/lib/threads/threadpool.cpp
+    ${TEST_DIR}/svs/lib/version.cpp
     ${TEST_DIR}/svs/lib/uuid.cpp
     # Third Party
     ${TEST_DIR}/svs/third-party/fmt.cpp

--- a/tests/svs/lib/saveload.cpp
+++ b/tests/svs/lib/saveload.cpp
@@ -73,30 +73,6 @@ bool operator==(const Saveable& a, const Saveable& b) {
 }
 } // namespace
 
-CATCH_TEST_CASE("Version Numbers", "[lib][save_load][versions]") {
-    namespace lib = svs::lib;
-    constexpr auto v = lib::Version(0, 2, 4);
-    auto x = lib::Version(0, 2, 4);
-    CATCH_REQUIRE(x == v);
-    CATCH_REQUIRE(!(x < v));
-
-    auto str = v.str();
-    CATCH_REQUIRE(str == "v0.2.4");
-    auto u = lib::Version(str);
-    CATCH_REQUIRE(u == v);
-    CATCH_REQUIRE(lib::Version("v10.20.355534") == lib::Version(10, 20, 355534));
-
-    // Comparison.
-    auto cmp = [](const lib::Version& left, const lib::Version& right) {
-        CATCH_REQUIRE(left < right);
-        CATCH_REQUIRE(!(right < left));
-    };
-
-    cmp(lib::Version(10, 20, 30), lib::Version(11, 20, 30));
-    cmp(lib::Version(10, 20, 30), lib::Version(10, 21, 30));
-    cmp(lib::Version(10, 20, 30), lib::Version(10, 20, 31));
-}
-
 CATCH_TEST_CASE("Save/Load", "[lib][save_load]") {
     // Setup the temporary directory.
     svs_test::prepare_temp_directory();

--- a/tests/svs/lib/version.cpp
+++ b/tests/svs/lib/version.cpp
@@ -1,0 +1,46 @@
+/**
+ *    Copyright (C) 2023-present, Intel Corporation
+ *
+ *    You can redistribute and/or modify this software under the terms of the
+ *    GNU Affero General Public License version 3.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    version 3 along with this software. If not, see
+ *    <https://www.gnu.org/licenses/agpl-3.0.en.html>.
+ */
+
+// header under test
+#include "svs/lib/version.h"
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+
+CATCH_TEST_CASE("Version Numbers", "[lib][versions]") {
+    namespace lib = svs::lib;
+    constexpr auto v = lib::Version(0, 2, 4);
+    auto x = lib::Version(0, 2, 4);
+    CATCH_REQUIRE(x == v);
+    CATCH_REQUIRE(!(x < v));
+
+    auto str = v.str();
+    CATCH_REQUIRE(str == "v0.2.4");
+    auto u = lib::Version(str);
+    CATCH_REQUIRE(u == v);
+    CATCH_REQUIRE(lib::Version("v10.20.355534") == lib::Version(10, 20, 355534));
+
+    // Comparison.
+    auto cmp = [](const lib::Version& left, const lib::Version& right) {
+        CATCH_REQUIRE(left < right);
+        CATCH_REQUIRE(!(right < left));
+    };
+
+    cmp(lib::Version(10, 20, 30), lib::Version(11, 20, 30));
+    cmp(lib::Version(10, 20, 30), lib::Version(10, 21, 30));
+    cmp(lib::Version(10, 20, 30), lib::Version(10, 20, 31));
+}
+
+// Keep in-sync with CMakeLists.txt
+CATCH_TEST_CASE("Global Version", "[lib][versions]") {
+    static_assert(svs::lib::svs_version == svs::lib::Version(0, 0, 1), "Version mismatch!");
+    CATCH_REQUIRE(svs::lib::svs_version == svs::lib::Version(0, 0, 1));
+}


### PR DESCRIPTION
This adds version support to the C++ library through CMake (imported into the library via macros). I'm not entirely sure how we want the version the Python library. For example, a change in version number of the C++ library will necessitate a version bump of the Python code, but a change to the Python code does not require a similar change to the C++ version.