### PR TITLE
Remove `num_threads` from `VamanaBuildParameters`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,14 @@
+# SVS 0.0.2 Release Notes
+
+## C++ Library
+
+* Enabled serialization of `VamanaBuildParameters`.
+* Removed `nthreads` member of `VamanaBuildParameters` and added the number of threads as
+  an argument to `svs::index::Vamana::build`.
+
+## PYSVS
+
+* Deprecated `num_threads` keyword argument from `pysvs.VamanaBuildParameters` and added
+  `num_threads` keyword to `pysvs.Vamana.build`.
+
+

--- a/bindings/python/tests/test_vamana.py
+++ b/bindings/python/tests/test_vamana.py
@@ -12,6 +12,8 @@
 # Tests for the Vamana index portion of the PySVS module.
 import unittest
 import os
+import warnings
+
 from tempfile import TemporaryDirectory
 
 import pysvs
@@ -191,6 +193,13 @@ class VamanaTester(unittest.TestCase):
         for loader, recall_dict in self.loader_and_recall:
             self._test_basic(loader, recall_dict)
 
+    def test_deprecation(self):
+        with warnings.catch_warnings(record = True) as w:
+            p = pysvs.VamanaBuildParameters(num_threads = 1)
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertTrue("VamanaBuildParameters" in str(w[0].message))
+
     def _alpha_map(self):
         return {
             pysvs.DistanceType.L2: 1.2,
@@ -252,9 +261,8 @@ class VamanaTester(unittest.TestCase):
             graph_max_degree = 30,
             window_size = 40,
             max_candidate_pool_size = 30,
-            num_threads = num_threads,
         )
-        vamana = pysvs.Vamana.build(parameters, data, distance)
+        vamana = pysvs.Vamana.build(parameters, data, distance, num_threads = num_threads)
 
         # Load the queries and groundtruth
         queries = pysvs.read_vecs(test_queries)
@@ -327,9 +335,10 @@ class VamanaTester(unittest.TestCase):
             graph_max_degree = 30,
             window_size = 40,
             max_candidate_pool_size = 30,
-            num_threads = num_threads,
         )
-        vamana = pysvs.Vamana.build(parameters, compressor, distance)
+        vamana = pysvs.Vamana.build(
+            parameters, compressor, distance, num_threads = num_threads
+        )
 
         # Load the queries and groundtruth
         queries = pysvs.read_vecs(test_queries)

--- a/examples/cpp/vamana.cpp
+++ b/examples/cpp/vamana.cpp
@@ -61,17 +61,17 @@ int svs_main(std::vector<std::string> args) {
 
     //! [Build Parameters]
     auto parameters = svs::index::vamana::VamanaBuildParameters{
-        1.2,  // alpha
-        64,   // graph max degree
-        128,  // search window size
-        1024, // max candidate pool size
-        4     // num threads
+        1.2, // alpha
+        64,  // graph max degree
+        128, // search window size
+        1024 // max candidate pool size
     };
     //! [Build Parameters]
 
     //! [Index Build]
+    size_t num_threads = 4;
     svs::Vamana index = svs::Vamana::build<float>(
-        parameters, svs::VectorDataLoader<float>(data_vecs), svs::DistanceL2()
+        parameters, svs::VectorDataLoader<float>(data_vecs), svs::DistanceL2(), num_threads
     );
     //! [Index Build]
 
@@ -135,7 +135,8 @@ int svs_main(std::vector<std::string> args) {
 
     //! [Build Index Compressed]
     // Compressed building
-    index = svs::Vamana::build<float>(parameters, compressor, svs::DistanceL2());
+    index =
+        svs::Vamana::build<float>(parameters, compressor, svs::DistanceL2(), num_threads);
     recall = run_recall(index, queries, groundtruth, 30, 10, "Compressed Build");
     check(0.8226, recall);
     //! [Build Index Compressed]

--- a/include/svs/index/vamana/build_params.h
+++ b/include/svs/index/vamana/build_params.h
@@ -26,14 +26,12 @@ struct VamanaBuildParameters {
         size_t graph_max_degree_,
         size_t window_size_,
         size_t max_candidate_pool_size_,
-        size_t nthreads_,
         bool use_full_search_history_ = true
     )
         : alpha{alpha_}
         , graph_max_degree{graph_max_degree_}
         , window_size{window_size_}
         , max_candidate_pool_size{max_candidate_pool_size_}
-        , nthreads{nthreads_}
         , use_full_search_history{use_full_search_history_} {}
 
     /// The pruning parameter.
@@ -54,15 +52,67 @@ struct VamanaBuildParameters {
     /// about it.
     size_t max_candidate_pool_size;
 
-    /// **Soon to be deprecated**: The number of threads to use for graph construction.
-    /// Reason for deprecation: Number of threads is often obtained from external sources
-    /// so including it in this struct no longer entirely makes sense.
-    size_t nthreads;
-
     /// When building, either the contents of the search buffer can be used or the entire
     /// search history can be used.
     ///
     /// The latter case may yield a slightly better graph as the cost of more search time.
     bool use_full_search_history = true;
+
+    ///// Comparison
+    friend bool
+    operator==(const VamanaBuildParameters&, const VamanaBuildParameters&) = default;
+
+    ///// Saving and Loading
+    static constexpr std::string_view name = "vamana build parameters";
+
+    // Change notes:
+    //
+    // v0.0.0 - Initial versiohn
+    static constexpr lib::Version save_version = lib::Version(0, 0, 0);
+
+    lib::SaveType save(const lib::SaveContext& SVS_UNUSED(ctx)) const {
+        auto table = toml::table(
+            {{"alpha", prepare(alpha)},
+             {"graph_max_degree", prepare(graph_max_degree)},
+             {"window_size", prepare(window_size)},
+             {"max_candidate_pool_size", prepare(max_candidate_pool_size)},
+             {"use_full_search_history", use_full_search_history},
+             {"name", name}}
+        );
+        return std::make_pair(std::move(table), save_version);
+    }
+
+    static VamanaBuildParameters load(
+        const toml::table& table,
+        const lib::LoadContext& SVS_UNUSED(ctx),
+        const lib::Version& version
+    ) {
+        // Perform a name check.
+        if (auto this_name = get_checked<std::string>(table, "name"); this_name != name) {
+            auto msg = fmt::format(
+                "Error deserializing VamanaConfigParameters. Expected name {}, got {}!",
+                name,
+                this_name
+            );
+            throw ANNEXCEPTION(msg);
+        }
+
+        // Version check
+        if (version != lib::Version(0, 0, 0)) {
+            throw ANNEXCEPTION("Incompatible version!");
+        }
+
+        // Okay - by this point we're satistifed that we're probably deserializing the
+        // correct object.
+        //
+        // Now, we finish loading.
+        return VamanaBuildParameters(
+            get<float>(table, "alpha"),
+            get<size_t>(table, "graph_max_degree"),
+            get<size_t>(table, "window_size"),
+            get<size_t>(table, "max_candidate_pool_size"),
+            get<bool>(table, "use_full_search_history")
+        );
+    }
 };
 } // namespace svs::index::vamana

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -636,7 +636,6 @@ class MutableVamanaIndex {
             graph_.max_degree(),
             construction_window_size_,
             max_candidates_,
-            threadpool_.size(),
             use_full_search_history_};
 
         VamanaBuilder builder{graph_, data_, distance_, parameters, threadpool_};

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -276,6 +276,7 @@ class Vamana : public manager::IndexManager<VamanaInterface, VamanaImpl> {
         const index::vamana::VamanaBuildParameters& parameters,
         DataLoader&& data_loader,
         Distance distance,
+        size_t num_threads = 1,
         const Allocator& graph_allocator = HugepageAllocator()
     ) {
         if constexpr (std::is_same_v<std::decay_t<Distance>, DistanceType>) {
@@ -286,7 +287,7 @@ class Vamana : public manager::IndexManager<VamanaInterface, VamanaImpl> {
                     parameters,
                     std::forward<DataLoader>(data_loader),
                     std::move(distance_function),
-                    parameters.nthreads,
+                    num_threads,
                     graph_allocator
                 );
             });
@@ -296,7 +297,7 @@ class Vamana : public manager::IndexManager<VamanaInterface, VamanaImpl> {
                 parameters,
                 std::forward<DataLoader>(data_loader),
                 distance,
-                parameters.nthreads,
+                num_threads,
                 graph_allocator
             );
         }

--- a/include/svs/third-party/toml.h
+++ b/include/svs/third-party/toml.h
@@ -34,8 +34,7 @@ inline bool maybe_config_file(const std::filesystem::path& path) {
     return path.extension() == ".toml";
 }
 
-template <typename T>
-const T& get_checked(const std::optional<T>& x, std::string_view key) {
+template <typename T> T get_checked(const std::optional<T>& x, std::string_view key) {
     if (!x.has_value()) {
         if constexpr (has_datatype_v<T>) {
             throw ANNEXCEPTION(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/svs/core/translation.cpp
     # Index Specific Functionality
     ${TEST_DIR}/svs/index/flat/inserters.cpp
+    ${TEST_DIR}/svs/index/vamana/build_parameters.cpp
     ${TEST_DIR}/svs/index/vamana/consolidate.cpp
     ${TEST_DIR}/svs/index/vamana/search_buffer.cpp
     ${TEST_DIR}/svs/index/vamana/vamana_build.cpp

--- a/tests/integration/index_build.cpp
+++ b/tests/integration/index_build.cpp
@@ -50,12 +50,11 @@ svs::Vamana build_index(
         max_degree,
         build_search_window_size,
         max_candidate_pool_size,
-        n_threads,
     };
 
     auto tic = svs::lib::now();
     svs::Vamana index = svs::Vamana::build<E>(
-        parameters, svs::VectorDataLoader<E, D>(vecs_filename), dist_type
+        parameters, svs::VectorDataLoader<E, D>(vecs_filename), dist_type, n_threads
     );
 
     auto diff = svs::lib::time_difference(tic);

--- a/tests/svs/index/vamana/build_parameters.cpp
+++ b/tests/svs/index/vamana/build_parameters.cpp
@@ -1,0 +1,49 @@
+/**
+ *    Copyright (C) 2023-present, Intel Corporation
+ *
+ *    You can redistribute and/or modify this software under the terms of the
+ *    GNU Affero General Public License version 3.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    version 3 along with this software. If not, see
+ *    <https://www.gnu.org/licenses/agpl-3.0.en.html>.
+ */
+
+// Header under test.
+#include "svs/index/vamana/build_params.h"
+
+// svs
+#include "svs/lib/saveload.h"
+
+// svs_test
+#include "tests/utils/utils.h"
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+
+CATCH_TEST_CASE("VamanaBuildParameters", "[index][vamana]") {
+    CATCH_SECTION("Constructors") {
+        auto p = svs::index::vamana::VamanaBuildParameters{1.2f, 64, 128, 750};
+        CATCH_REQUIRE(p.alpha == 1.2f);
+        CATCH_REQUIRE(p.graph_max_degree == 64);
+        CATCH_REQUIRE(p.window_size == 128);
+        CATCH_REQUIRE(p.max_candidate_pool_size == 750);
+        // Default applied parameters.
+        CATCH_REQUIRE(p.use_full_search_history == true);
+
+        // Check for equality and use of the 5-argument constructor.
+        auto u = svs::index::vamana::VamanaBuildParameters{1.2, 64, 128, 750, false};
+        CATCH_REQUIRE(p != u);
+        u.use_full_search_history = true;
+        CATCH_REQUIRE(p == u);
+    }
+
+    // Serialization.
+    CATCH_SECTION("Serialization") {
+        svs_test::prepare_temp_directory();
+        auto temp_directory = svs_test::temp_directory();
+
+        auto p = svs::index::vamana::VamanaBuildParameters{1.2, 64, 128, 750, false};
+        CATCH_REQUIRE(svs::lib::test_self_save_load(p, temp_directory));
+    }
+}

--- a/tests/svs/index/vamana/dynamic_index_2.cpp
+++ b/tests/svs/index/vamana/dynamic_index_2.cpp
@@ -283,7 +283,7 @@ CATCH_TEST_CASE("Testing Graph Index", "[graph_index][dynamic_index]") {
     }
 
     svs::index::vamana::VamanaBuildParameters parameters{
-        1.2, max_degree, 2 * max_degree, 1000, num_threads};
+        1.2, max_degree, 2 * max_degree, 1000};
 
     auto tic = svs::lib::now();
     auto index = svs::index::vamana::MutableVamanaIndex(

--- a/utils/benchmarks/index_build.cpp
+++ b/utils/benchmarks/index_build.cpp
@@ -76,8 +76,7 @@ std::vector<BenchmarkResult> benchmark(
         build_setup.alpha,
         build_setup.max_degree,
         build_setup.construction_window_size,
-        1000,
-        num_threads};
+        1000};
 
     auto build_time = timer.push_back("index build");
     auto index = svs::index::vamana::auto_build(

--- a/utils/build_index.cpp
+++ b/utils/build_index.cpp
@@ -49,15 +49,10 @@ void build_index(
 
     auto tic = std::chrono::steady_clock::now();
     svs::index::vamana::VamanaBuildParameters parameters{
-        alpha,
-        max_degree,
-        build_search_window_size,
-        max_candidate_pool_size,
-        n_threads,
-    };
+        alpha, max_degree, build_search_window_size, max_candidate_pool_size};
 
     auto index = svs::Vamana::build<E>(
-        parameters, svs::VectorDataLoader<E, D>(vecs_filename), dist_type
+        parameters, svs::VectorDataLoader<E, D>(vecs_filename), dist_type, n_threads
     );
     index.save(config_directory, graph_directory, data_directory);
     auto toc = std::chrono::steady_clock::now();

--- a/utils/characterization/mutable.cpp
+++ b/utils/characterization/mutable.cpp
@@ -274,7 +274,7 @@ int svs_main(std::vector<std::string> args) {
     }
 
     svs::index::vamana::VamanaBuildParameters parameters{
-        ALPHA, max_degree, 2 * max_degree, 1000, num_threads};
+        ALPHA, max_degree, 2 * max_degree, 1000};
 
     auto tic = svs::lib::now();
     auto index = svs::index::vamana::MutableVamanaIndex(

--- a/utils/quantization/build_quantized.cpp
+++ b/utils/quantization/build_quantized.cpp
@@ -31,8 +31,7 @@ int svs_main(std::vector<std::string> args) {
     const size_t num_threads = 10;
     const size_t max_degree = 64;
 
-    auto parameters =
-        svs::index::vamana::VamanaBuildParameters{1.2, max_degree, 100, 1000, num_threads};
+    auto parameters = svs::index::vamana::VamanaBuildParameters{1.2, max_degree, 100, 1000};
 
     auto index = svs::index::vamana::auto_build(
         parameters,

--- a/utils/quantization/dynamic_lvq.cpp
+++ b/utils/quantization/dynamic_lvq.cpp
@@ -52,8 +52,8 @@ int svs_main(std::vector<std::string> args) {
     auto lvq_dataset = compressor.compress(data, svs::data::BlockedBuilder());
 
     size_t max_degree = 32;
-    auto parameters = svs::index::vamana::VamanaBuildParameters{
-        1.2, max_degree, 2 * max_degree, 1000, num_threads};
+    auto parameters =
+        svs::index::vamana::VamanaBuildParameters{1.2, max_degree, 2 * max_degree, 1000};
 
     auto index = svs::index::vamana::MutableVamanaIndex{
         parameters, std::move(lvq_dataset), ids, svs::distance::DistanceL2(), num_threads};


### PR DESCRIPTION
Additionally

* Enable serialization of the parameters in prepartion for index building benchmarking.
* Introduce a NEWS.md file where API changes can be recorded going forward.
* Add VamanaBuildParaameters change to NEWS.md