### PR TITLE
Removed use of variables after move

### DIFF
--- a/include/svs/misc/dynamic_helper.h
+++ b/include/svs/misc/dynamic_helper.h
@@ -163,7 +163,7 @@ template <typename Idx, typename Eltype, size_t N, typename Dist> class Referenc
 
         auto timer = lib::Timer();
         size_t start = 0;
-        size_t datasize = data.size();
+        size_t datasize = data_.size();
         size_t num_queries = queries.size();
         while (start < datasize) {
             // Create a bucket of sequential IDs.

--- a/include/svs/quantization/lvq/lvq.h
+++ b/include/svs/quantization/lvq/lvq.h
@@ -225,8 +225,8 @@ class LVQDataset {
     LVQDataset(primary_type primary, residual_type residual)
         : primary_{std::move(primary)}
         , residual_{std::move(residual)} {
-        auto primary_size = primary.size();
-        auto residual_size = residual.size();
+        auto primary_size = primary_.size();
+        auto residual_size = residual_.size();
         if (primary_size != residual_size) {
             auto msg = fmt::format(
                 "Primary size is {} while residual size is {}!", primary_size, residual_size
@@ -234,8 +234,8 @@ class LVQDataset {
             throw ANNEXCEPTION(msg);
         }
 
-        auto primary_dims = primary.dimensions();
-        auto residual_dims = residual.dimensions();
+        auto primary_dims = primary_.dimensions();
+        auto residual_dims = residual_.dimensions();
         if (primary_dims != residual_dims) {
             auto msg = fmt::format(
                 "Primary dimensions is {} while residual dimensions is {}!",


### PR DESCRIPTION
Coverity caught some benign issues with using objects after moving. Replaced the usages with local/private objects.