### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -39,8 +39,8 @@ jobs:
 
       - name: Build Wheel
         env:
-          CC: clang-13
-          CXX: clang++-13
+          CC: clang-14
+          CXX: clang++-14
         run: |
           cd ${GITHUB_WORKSPACE}/bindings/python
           python setup.py bdist_wheel --cmake-executable="cmake" --build-type=Debug -- -- -j2

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Build Wheel
         env:
-          CC: clang-14
-          CXX: clang++-14
+          CC: clang-15
+          CXX: clang++-15
         run: |
           cd ${GITHUB_WORKSPACE}/bindings/python
           python setup.py bdist_wheel --cmake-executable="cmake" --build-type=Debug -- -- -j2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        cxx: [g++-11, g++-12, clang++-14]
+        cxx: [g++-11, g++-12, clang++-15]
         include:
           - cxx: g++-11
             cc: gcc-11
           - cxx: g++-12
             cc: gcc-12
-          - cxx: clang++-14
-            cc: clang-14
+          - cxx: clang++-15
+            cc: clang-15
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,17 +21,17 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        cxx: [g++-11, g++-12, clang++-13]
+        cxx: [g++-11, g++-12, clang++-14]
         include:
           - cxx: g++-11
             cc: gcc-11
           - cxx: g++-12
             cc: gcc-12
-          - cxx: clang++-13
-            cc: clang-13
+          - cxx: clang++-14
+            cc: clang-14
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure build
       working-directory: ${{ runner.temp }}
       env:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -45,8 +45,8 @@ jobs:
 
       - name: Build Wheel
         env:
-          CC: clang-13
-          CXX: clang++-13
+          CC: clang-14
+          CXX: clang++-14
         run: |
           cd ${GITHUB_WORKSPACE}/bindings/python
           python setup.py bdist_wheel --cmake-executable="cmake" --build-type=Debug -- -- -j2

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Build Wheel
         env:
-          CC: clang-14
-          CXX: clang++-14
+          CC: clang-15
+          CXX: clang++-15
         run: |
           cd ${GITHUB_WORKSPACE}/bindings/python
           python setup.py bdist_wheel --cmake-executable="cmake" --build-type=Debug -- -- -j2

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -22,7 +22,7 @@ config-settings = {}
 dependency-versions = "pinned"
 environment.CC = "/opt/rh/devtoolset-11/root/usr/bin/cc"
 environment.CXX = "/opt/rh/devtoolset-11/root/usr/bin/c++"
-# Compile multiple versions for difference microarchitectures
+# Compile multiple versions for differenct microarchitectures
 environment.PYSVS_MULTIARCH = "YES"
 environment-pass = []
 build-verbosity = "3"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -20,7 +20,7 @@ def target(arch):
 if os.environ.get("PYSVS_MULTIARCH", None) is not None:
     pysvs_microarchs = [
         "cascadelake",
-        "x86_64_v3", # common base CPU for Intel and Zen
+        "x86_64_v3", # conservative base CPU for x86 CPUs.
     ]
 
     # Add the current host to the list of micro-architecture if it doesn't already exist.

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -20,7 +20,7 @@ def target(arch):
 if os.environ.get("PYSVS_MULTIARCH", None) is not None:
     pysvs_microarchs = [
         "cascadelake",
-        # "skylake_avx512",
+        "x86_64_v3", # common base CPU for Intel and Zen
     ]
 
     # Add the current host to the list of micro-architecture if it doesn't already exist.

--- a/bindings/python/src/pysvs/loader.py
+++ b/bindings/python/src/pysvs/loader.py
@@ -33,6 +33,16 @@ def _override_backend():
     """
     return os.environ.get("PYSVS_OVERRIDE_BACKEND", None)
 
+def _debug_override_cpu():
+    """
+    Set the current CPU microarchitecture.
+    Unlike `_override_backend()`, the loader will still perform backend-selection based
+    on this architecture.
+
+    If no override is set, return `None`.
+    """
+    return os.environ.get("PYSVS_DEBUG_OVERRIDE_CPU", None)
+
 
 # The name of the manifest file.
 FLAGS_MANIFEST = "flags_manifest.json" # Keep in-sync with CMakeLists.txt
@@ -122,7 +132,14 @@ def _find_library():
 
     # Get the current CPU and the manifest of compiled libraries that ship with this
     # library.
+    #
+    # For debug purposes, allow the CPU to be set externally rather than using archspec's
+    # CPU detection.
     host = cpu.host()
+    debug_override = _debug_override_cpu()
+    if debug_override is not None:
+        host = debug_override
+
     manifest = _load_manifest()
 
     # Respect override requests.


### PR DESCRIPTION
## Upgrade the GitHub actions "checkout" from v2/v3 to v4.

This should be relatively minor.

## Increase the version of clang used in CI to version ~~14~~ 15.
Version 13 does not seem to have sufficient support for GCC's `libstdc++` version 13.
If we want, we can probably still test older versions of clang using an `unbuntu-20` based runner instead that ships with a lower version of `libstdc++`.

~~We *may* have to bump this to version 15 if we're still seeing failures.~~ We did.

## Add a generic `x86_64_v3` backend for cibuildwheel builds.
The generic `x86_64_v3` should be compatible with most x86 architectures (with degraded performance).
