### PR TITLE
Fix MinRange intialization

### DIFF
--- a/include/svs/quantization/lvq/codec.h
+++ b/include/svs/quantization/lvq/codec.h
@@ -131,7 +131,7 @@ template <size_t Residual> class ResidualEncoder : public CVStorage {
     CompressedVector<Signed, Residual, Primary::extent, Sequential>
     operator()(const Primary& primary, lib::AnySpanLike auto data) {
         // Compute the scaling factor for the residual.
-        float decompressor = primary.get_scale() / (std::pow(2, Residual));
+        float decompressor = primary.get_scale() / (std::pow(2, Residual) - 1);
         float compressor = 1.0f / decompressor;
 
         // Round the difference between the primary compression and the

--- a/include/svs/quantization/lvq/codec.h
+++ b/include/svs/quantization/lvq/codec.h
@@ -131,7 +131,7 @@ template <size_t Residual> class ResidualEncoder : public CVStorage {
     CompressedVector<Signed, Residual, Primary::extent, Sequential>
     operator()(const Primary& primary, lib::AnySpanLike auto data) {
         // Compute the scaling factor for the residual.
-        float decompressor = primary.get_scale() / (std::pow(2, Residual) - 1);
+        float decompressor = primary.get_scale() / (std::pow(2, Residual));
         float compressor = 1.0f / decompressor;
 
         // Round the difference between the primary compression and the

--- a/include/svs/quantization/lvq/codec.h
+++ b/include/svs/quantization/lvq/codec.h
@@ -67,7 +67,7 @@ class MinRange : public CVStorage {
         }
 
         float min{std::numeric_limits<float>::max()};
-        float max{std::numeric_limits<float>::min()};
+        float max{std::numeric_limits<float>::lowest()};
         for (size_t i = 0; i < data.size(); ++i) {
             float val = static_cast<float>(data[i]);
             min = std::min(min, val);


### PR DESCRIPTION
* Fix1: The standard function `std::numeric_limits<float>::min()` returns the lowest *positive* floating point value. this approach might fail to find the actual maximum in vectors containing only negative values.
The solution is to use `std::numeric_limits<float>::lowest()` instead
