### PR TITLE
Allow cibuildwheel to be canceled by new commits.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -6,6 +6,13 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: 'cibuildwheel'
+  cancel-in-progress: true
+
 jobs:
   python-build:
     name: Build Wheel

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: 'cibuildwheel'
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The recent [sync pr](#30) resulted in a bunch of commits with CI running on each commit. This is less than ideal and just wastes CI resources.

Most of our actions were set up to auto-cancel on new commit, but cibuildwheel was not.