### PR TITLE
Reroute core logging prints to stderr

### DIFF
--- a/include/svs/index/inverted/clustering.h
+++ b/include/svs/index/inverted/clustering.h
@@ -812,7 +812,7 @@ Clustering<I> cluster_with(
     auto timer = lib::Timer();
     while (start < datasize) {
         size_t stop = std::min(start + batchsize, datasize);
-        fmt::print("Processing batch [{}, {})\n", start, stop);
+        fmt::print(stderr, "Processing batch [{}, {})\n", start, stop);
         auto indices = clustering.complement_range(threads::UnitRange(start, stop));
         auto subdata = extensions::prepare_index_search(data, lib::as_const_span(indices));
 
@@ -839,7 +839,7 @@ Clustering<I> cluster_with(
         start = stop;
     }
     timer.print();
-    fmt::print("Clustering Stats: {}\n", clustering.statistics().report("\n"));
+    fmt::print(stderr, "Clustering Stats: {}\n", clustering.statistics().report("\n"));
 
     // Post Processing
     auto max_cluster_size = params.max_cluster_size_;

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -819,10 +819,10 @@ class MutableVamanaIndex {
         assert(entry_point_.size() == 1);
         auto entry_point = entry_point_[0];
         if (status_.at(entry_point) == SlotMetadata::Deleted) {
-            fmt::print("Replacing entry point! ... ");
+            fmt::print(stderr, "Replacing entry point! ... ");
             auto new_entry_point =
                 extensions::compute_entry_point(data_, threadpool_, valid);
-            fmt::print(" New point: {}\n", new_entry_point);
+            fmt::print(stderr, " New point: {}\n", new_entry_point);
             assert(!is_deleted(new_entry_point));
             entry_point_[0] = new_entry_point;
         }

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -95,7 +95,8 @@ struct VamanaIndexParameters {
     }
 
     static VamanaIndexParameters load_legacy(const lib::ContextFreeLoadTable& table) {
-        fmt::print("Loading a legacy IndexParameters class. Please consider resaving this "
+        fmt::print(stderr,
+                   "Loading a legacy IndexParameters class. Please consider resaving this "
                    "index to update the save version and prevent future breaking!\n");
 
         if (table.version() > lib::Version{0, 0, 2}) {

--- a/include/svs/index/vamana/vamana_build.h
+++ b/include/svs/index/vamana/vamana_build.h
@@ -215,8 +215,8 @@ class VamanaBuilder {
         unsigned progress_counter = 0;
 
         if (verbose) {
-            fmt::print("Number of syncs: {}\n", num_batches);
-            fmt::print("Batch Size: {}\n", batchsize);
+            fmt::print(stderr, "Number of syncs: {}\n", num_batches);
+            fmt::print(stderr, "Batch Size: {}\n", batchsize);
         }
 
         // The base point for iteration.
@@ -258,6 +258,7 @@ class VamanaBuilder {
                         "Estimated Remaining Time: {:.4}s\n";
 
                     fmt::print(
+                        stderr, 
                         message,
                         batch_id + 1,
                         num_batches,
@@ -273,7 +274,7 @@ class VamanaBuilder {
             }
         }
         if (verbose) {
-            fmt::print("Completed pass using window size {}.\n", params_.window_size);
+            fmt::print(stderr, "Completed pass using window size {}.\n", params_.window_size);
             timer.print();
         }
     }

--- a/include/svs/lib/timing.h
+++ b/include/svs/lib/timing.h
@@ -275,6 +275,7 @@ class Timer {
         auto hyphens = std::string(str.size(), '-');
         auto [measured_formatted, measured_units] = pretty_number(measured_time);
         fmt::print(
+            stderr, 
             "{}\n"
             "Total / % Measured: {:.4} {} / {:.4}\n"
             "{}\n"
@@ -290,7 +291,7 @@ class Timer {
         for (const auto& it : subtimers()) {
             (it.second)->print_inner(section_length, measured_time, 0, it.first);
         }
-        fmt::print("{}\n", hyphens);
+        fmt::print(stderr, "{}\n", hyphens);
     }
 
     void print_inner(
@@ -310,6 +311,7 @@ class Timer {
         auto [max_time_format, max_time_units] = pretty_number(max_time);
 
         fmt::print(
+            stderr, 
             "{}{}{}{:10}{:10.4}{:>3}{:12.4}{:10.4}{:>3}{:10.4}{:>3}{:10.4}{:>3}\n",
             prefix,
             label,


### PR DESCRIPTION
Prints to stdout in core functionality cause stream parsing issues if it's part of user workload.