### PR TITLE
Specialize `as_const_span` for `svs::AnonymousArray<1>` (#352)

### DIFF
--- a/include/svs/lib/datatype.h
+++ b/include/svs/lib/datatype.h
@@ -439,6 +439,13 @@ template <size_t N> class AnonymousArray {
         return dims_[i];
     }
 
+    /// @brief Return the number of elements in a 1-dimensional array.
+    size_t size() const
+        requires(N == 1)
+    {
+        return size(0);
+    }
+
     /// @brief Return the based pointer performing a checked cast.
     template <typename T> const T* data() const { return get<T>(data_); }
 

--- a/include/svs/lib/misc.h
+++ b/include/svs/lib/misc.h
@@ -18,6 +18,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "svs/lib/datatype.h"
 #include "svs/lib/exception.h"
 #include "svs/lib/meta.h"
 
@@ -100,6 +101,15 @@ std::span<const T> as_const_span(const std::vector<T, Alloc>& v) {
 template <typename T, typename Alloc>
 std::span<const T> as_span(const std::vector<T, Alloc>& v) {
     return as_const_span(v);
+}
+
+template <typename T>
+std::span<const T> as_const_span(const svs::AnonymousArray<1>& array) {
+    return std::span<const T>(get<T>(array), array.size());
+}
+
+template <typename T> std::span<const T> as_span(const svs::AnonymousArray<1>& array) {
+    return as_const_span<const T>(array);
 }
 
 namespace detail {

--- a/include/svs/lib/preprocessor.h
+++ b/include/svs/lib/preprocessor.h
@@ -153,4 +153,4 @@ inline constexpr bool have_avx512_avx2 = true;
 inline constexpr bool have_avx512_avx2 = true;
 #endif
 
-} // namespace arch
+} // namespace svs::arch

--- a/tests/svs/lib/datatype.cpp
+++ b/tests/svs/lib/datatype.cpp
@@ -13,6 +13,9 @@
 #include "svs/lib/datatype.h"
 #include "svs/lib/saveload.h"
 
+// svstest
+#include "tests/utils/require_error.h"
+
 // catch2
 #include "catch2/catch_test_macros.hpp"
 
@@ -149,6 +152,10 @@ CATCH_TEST_CASE("Data Type", "[core][datatype]") {
             CATCH_REQUIRE(x.type() == svs::datatype_v<int>);
             CATCH_REQUIRE(x.pointer() == svs::ConstErasedPointer(v.data()));
             CATCH_REQUIRE(x.size(0) == 3);
+            CATCH_REQUIRE(x.size() == 3); // Special member for 1-dimensional array.
+
+            SVS_REQUIRE_COMPILES(svs::AnonymousArray<1>, (std::declval<TestType>().size()));
+
             CATCH_REQUIRE(svs::get<int>(x) == v.data());
             CATCH_REQUIRE_THROWS_AS(svs::get<float>(x), svs::ANNException);
             CATCH_REQUIRE(x.template data_unchecked<int>() == v.data());
@@ -168,6 +175,11 @@ CATCH_TEST_CASE("Data Type", "[core][datatype]") {
             CATCH_REQUIRE(x.pointer() == svs::ConstErasedPointer(v.data()));
             CATCH_REQUIRE(x.size(0) == 3);
             CATCH_REQUIRE(x.size(1) == 2);
+
+            SVS_REQUIRE_DOES_NOT_COMPILE(
+                svs::AnonymousArray<2>, (std::declval<TestType>().size())
+            );
+
             CATCH_REQUIRE(svs::get<uint32_t>(x) == v.data());
             CATCH_REQUIRE_THROWS_AS(svs::get<int>(x), svs::ANNException);
             CATCH_REQUIRE(x.template data_unchecked<uint32_t>() == v.data());
@@ -188,6 +200,11 @@ CATCH_TEST_CASE("Data Type", "[core][datatype]") {
             CATCH_REQUIRE(x.size(0) == 2);
             CATCH_REQUIRE(x.size(1) == 2);
             CATCH_REQUIRE(x.size(2) == 2);
+
+            SVS_REQUIRE_DOES_NOT_COMPILE(
+                svs::AnonymousArray<3>, (std::declval<TestType>().size())
+            );
+
             CATCH_REQUIRE(svs::get<uint32_t>(x) == v.data());
             CATCH_REQUIRE_THROWS_AS(svs::get<int>(x), svs::ANNException);
             CATCH_REQUIRE(x.template data_unchecked<uint32_t>() == v.data());

--- a/tests/svs/lib/misc.cpp
+++ b/tests/svs/lib/misc.cpp
@@ -118,6 +118,31 @@ CATCH_TEST_CASE("Misc", "[core][misc]") {
                 svs::lib::as_span<11>(std::as_const(x)), svs::ANNException
             );
         }
+
+        // Anonymous Array
+        {
+            auto a = svs::AnonymousArray<1>(x.data(), x.size());
+
+            // as_const_span
+            std::span<const float> sp = svs::lib::as_const_span<float>(a);
+            CATCH_REQUIRE(sp.size() == x.size());
+            CATCH_REQUIRE(std::equal(sp.begin(), sp.end(), x.begin()));
+            CATCH_REQUIRE(sp.data() == x.data());
+
+            // as_span
+            sp = svs::lib::as_span<float>(a);
+            CATCH_REQUIRE(sp.size() == x.size());
+            CATCH_REQUIRE(std::equal(sp.begin(), sp.end(), x.begin()));
+            CATCH_REQUIRE(sp.data() == x.data());
+
+            // Trying to extract an incorrect type should be a runtime error.
+            CATCH_REQUIRE_THROWS_AS(
+                svs::lib::as_const_span<svs::Float16>(a), svs::ANNException
+            );
+            CATCH_REQUIRE_THROWS_AS(
+                svs::lib::as_const_span<double>(a), svs::ANNException
+            );
+        }
     }
 
     CATCH_SECTION("Identity") {

--- a/tests/utils/require_error.cpp
+++ b/tests/utils/require_error.cpp
@@ -26,5 +26,6 @@ struct Add {
 
 CATCH_TEST_CASE("SFINAE Checker") {
     CATCH_STATIC_REQUIRE(Add<int>::value);
+    SVS_REQUIRE_COMPILES(int, Add<TestType>::value);
     SVS_REQUIRE_DOES_NOT_COMPILE(char*, Add<TestType>::value);
 }

--- a/tests/utils/require_error.h
+++ b/tests/utils/require_error.h
@@ -22,3 +22,11 @@
         }.template operator()<Type>();                     \
         CATCH_STATIC_REQUIRE_FALSE(Result);                \
     }
+
+#define SVS_REQUIRE_COMPILES(Type, ...)                    \
+    {                                                      \
+        constexpr auto Result = [&]<typename TestType>() { \
+            return requires { __VA_ARGS__; };              \
+        }.template operator()<Type>();                     \
+        CATCH_STATIC_REQUIRE(Result);                      \
+    }


### PR DESCRIPTION
Specialize `as_const_span` for `svs::AnonymousArray<1>` (#352)

Specialize `svs::lib::as_span` and `svs::lib::as_const_span` for
`svs::AnonymousArray<1>`.
I've been finding myself needing something like this for the iterator
and figured it was probably generally useful.
