### PR TITLE
Bug Fix: Sort Search Buffer Before Node Insertion

### DIFF
--- a/include/svs/index/vamana/extensions.h
+++ b/include/svs/index/vamana/extensions.h
@@ -436,6 +436,7 @@ void check_and_supplement_search_buffer(
 ) {
     if (search_buffer.valid() < search_buffer.target_window() &&
         search_buffer.valid() < index.size()) {
+        search_buffer.sort();
         for (auto external_id : index.external_ids()) {
             auto internal_id = index.translate_external_id(external_id);
             auto dist = index.get_distance(external_id, query);


### PR DESCRIPTION
Summary:
This PR fixes a bug in the Vamana index search buffer logic by adding a sort operation before inserting nodes. The change ensures that buffer invariants are maintained during the search process.

Changes:
-  Added search_buffer.sort() call in check_and_supplement_search_buffer() function
- Ensures proper ordering before inserting new nodes into the search buffer

Impact:

- Fixes potential correctness issues in Vamana index search operations
- Maintains data structure invariants that were previously being violated
- Performance impact is minimal as this code path is only executed in rare corner cases when:
  - The search buffer has fewer valid entries than the target window size
  - AND there are still unused nodes available in the index
  - This typically occurs when the graph becomes sparsely connected

This is a targeted bug fix that addresses a specific issue where the search buffer wasn't properly sorted before node insertions in edge cases, which could lead to incorrect search results or violated invariants in the Vamana graph search algorithm.