### PR TITLE
Replace macros with runtime_error_wrapper() for error handling

### DIFF
--- a/bindings/cpp/src/dynamic_vamana_index.cpp
+++ b/bindings/cpp/src/dynamic_vamana_index.cpp
@@ -55,28 +55,25 @@ struct DynamicVamanaIndexManagerBase : public DynamicVamanaIndex {
     ~DynamicVamanaIndexManagerBase() override = default;
 
     Status add(size_t n, const size_t* labels, const float* x) noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        svs::data::ConstSimpleDataView<float> data{x, n, impl_->dimensions()};
-        std::span<const size_t> lbls(labels, n);
-        impl_->add(data, lbls);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] {
+            svs::data::ConstSimpleDataView<float> data{x, n, impl_->dimensions()};
+            std::span<const size_t> lbls(labels, n);
+            impl_->add(data, lbls);
+        });
     }
 
     Status
     remove_selected(size_t* num_removed, const IDFilter& selector) noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        *num_removed = impl_->remove_selected(selector);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] {
+            *num_removed = impl_->remove_selected(selector);
+        });
     }
 
     Status remove(size_t n, const size_t* labels) noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        std::span<const size_t> lbls(labels, n);
-        impl_->remove(lbls);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] {
+            std::span<const size_t> lbls(labels, n);
+            impl_->remove(lbls);
+        });
     }
 
     Status search(
@@ -88,12 +85,11 @@ struct DynamicVamanaIndexManagerBase : public DynamicVamanaIndex {
         const SearchParams* params = nullptr,
         IDFilter* filter = nullptr
     ) const noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        // TODO wrap arguments into proper data structures in DynamicVamanaIndexImpl and
-        // here
-        impl_->search(n, x, k, distances, labels, params, filter);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] {
+            // TODO wrap arguments into proper data structures in DynamicVamanaIndexImpl and
+            // here
+            impl_->search(n, x, k, distances, labels, params, filter);
+        });
     }
 
     Status range_search(
@@ -104,26 +100,19 @@ struct DynamicVamanaIndexManagerBase : public DynamicVamanaIndex {
         const SearchParams* params = nullptr,
         IDFilter* filter = nullptr
     ) const noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        // TODO wrap arguments into proper data structures in DynamicVamanaIndexImpl and
-        // here
-        impl_->range_search(n, x, radius, results, params, filter);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] {
+            // TODO wrap arguments into proper data structures in DynamicVamanaIndexImpl and
+            // here
+            impl_->range_search(n, x, radius, results, params, filter);
+        });
     }
 
     Status reset() noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        impl_->reset();
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] { impl_->reset(); });
     }
 
     Status save(std::ostream& out) const noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        impl_->save(out);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] { impl_->save(out); });
     }
 };
 
@@ -142,20 +131,16 @@ Status DynamicVamanaIndex::build(
     const DynamicVamanaIndex::SearchParams& default_search_params
 ) noexcept {
     *index = nullptr;
-    SVS_RUNTIME_TRY_BEGIN
-    auto impl = std::make_unique<DynamicVamanaIndexImpl>(
-        dim, metric, storage_kind, params, default_search_params
-    );
-    *index = new DynamicVamanaIndexManager{std::move(impl)};
-    return Status_Ok;
-    SVS_RUNTIME_TRY_END
+    return runtime_error_wrapper([&] {
+        auto impl = std::make_unique<DynamicVamanaIndexImpl>(
+            dim, metric, storage_kind, params, default_search_params
+        );
+        *index = new DynamicVamanaIndexManager{std::move(impl)};
+    });
 }
 
 Status DynamicVamanaIndex::destroy(DynamicVamanaIndex* index) noexcept {
-    SVS_RUNTIME_TRY_BEGIN
-    delete index;
-    return Status_Ok;
-    SVS_RUNTIME_TRY_END
+    return runtime_error_wrapper([&] { delete index; });
 }
 
 Status DynamicVamanaIndex::load(
@@ -165,12 +150,11 @@ Status DynamicVamanaIndex::load(
     StorageKind storage_kind
 ) noexcept {
     *index = nullptr;
-    SVS_RUNTIME_TRY_BEGIN
-    std::unique_ptr<DynamicVamanaIndexImpl> impl{
-        DynamicVamanaIndexImpl::load(in, metric, storage_kind)};
-    *index = new DynamicVamanaIndexManager{std::move(impl)};
-    return Status_Ok;
-    SVS_RUNTIME_TRY_END
+    return runtime_error_wrapper([&] {
+        std::unique_ptr<DynamicVamanaIndexImpl> impl{
+            DynamicVamanaIndexImpl::load(in, metric, storage_kind)};
+        *index = new DynamicVamanaIndexManager{std::move(impl)};
+    });
 }
 
 // Specialization to build LeanVec-based Vamana index with specified leanvec dims
@@ -184,13 +168,12 @@ Status DynamicVamanaIndexLeanVec::build(
     const DynamicVamanaIndex::SearchParams& default_search_params
 ) noexcept {
     *index = nullptr;
-    SVS_RUNTIME_TRY_BEGIN
-    auto impl = std::make_unique<DynamicVamanaIndexLeanVecImpl>(
-        dim, metric, storage_kind, leanvec_dims, params, default_search_params
-    );
-    *index = new DynamicVamanaIndexLeanVecImplManager{std::move(impl)};
-    return Status_Ok;
-    SVS_RUNTIME_TRY_END
+    return runtime_error_wrapper([&] {
+        auto impl = std::make_unique<DynamicVamanaIndexLeanVecImpl>(
+            dim, metric, storage_kind, leanvec_dims, params, default_search_params
+        );
+        *index = new DynamicVamanaIndexLeanVecImplManager{std::move(impl)};
+    });
 }
 
 // Specialization to build LeanVec-based Vamana index with provided training data
@@ -204,15 +187,14 @@ Status DynamicVamanaIndexLeanVec::build(
     const DynamicVamanaIndex::SearchParams& default_search_params
 ) noexcept {
     *index = nullptr;
-    SVS_RUNTIME_TRY_BEGIN
-    auto training_data_impl =
-        static_cast<const LeanVecTrainingDataManager*>(training_data)->impl_;
-    auto impl = std::make_unique<DynamicVamanaIndexLeanVecImpl>(
-        dim, metric, storage_kind, training_data_impl, params, default_search_params
-    );
-    *index = new DynamicVamanaIndexLeanVecImplManager{std::move(impl)};
-    return Status_Ok;
-    SVS_RUNTIME_TRY_END
+    return runtime_error_wrapper([&] {
+        auto training_data_impl =
+            static_cast<const LeanVecTrainingDataManager*>(training_data)->impl_;
+        auto impl = std::make_unique<DynamicVamanaIndexLeanVecImpl>(
+            dim, metric, storage_kind, training_data_impl, params, default_search_params
+        );
+        *index = new DynamicVamanaIndexLeanVecImplManager{std::move(impl)};
+    });
 }
 
 } // namespace runtime

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -65,29 +65,8 @@ class StatusException : public svs::lib::ANNException {
     svs::runtime::ErrorCode errcode_;
 };
 
-#define SVS_RUNTIME_TRY_BEGIN try {
-#define SVS_RUNTIME_TRY_END                                                                \
-    }                                                                                      \
-    catch (const svs::runtime::StatusException& ex) {                                      \
-        return svs::runtime::Status(ex.code(), ex.what());                                 \
-    }                                                                                      \
-    catch (const std::invalid_argument& ex) {                                              \
-        return svs::runtime::Status(svs::runtime::ErrorCode::INVALID_ARGUMENT, ex.what()); \
-    }                                                                                      \
-    catch (const std::runtime_error& ex) {                                                 \
-        return svs::runtime::Status(svs::runtime::ErrorCode::RUNTIME_ERROR, ex.what());    \
-    }                                                                                      \
-    catch (const std::exception& ex) {                                                     \
-        return svs::runtime::Status(svs::runtime::ErrorCode::UNKNOWN_ERROR, ex.what());    \
-    }                                                                                      \
-    catch (...) {                                                                          \
-        return svs::runtime::Status(                                                       \
-            svs::runtime::ErrorCode::UNKNOWN_ERROR, "An unknown error has occurred."       \
-        );                                                                                 \
-    }
-
 template <typename Callable>
-inline auto safe_runtime_call(Callable&& func) noexcept -> Status {
+inline auto runtime_error_wrapper(Callable&& func) noexcept -> Status {
     try {
         func();
         return Status_Ok;

--- a/bindings/cpp/src/training.cpp
+++ b/bindings/cpp/src/training.cpp
@@ -28,7 +28,7 @@ Status LeanVecTrainingData::build(
     const float* x,
     size_t leanvec_dims
 ) noexcept {
-    return safe_runtime_call([&] {
+    return runtime_error_wrapper([&] {
         const auto data = svs::data::ConstSimpleDataView<float>(x, n, dim);
         *training_data =
             new LeanVecTrainingDataManager{LeanVecTrainingDataImpl{data, leanvec_dims}};
@@ -36,12 +36,12 @@ Status LeanVecTrainingData::build(
 }
 
 Status LeanVecTrainingData::destroy(LeanVecTrainingData* training_data) noexcept {
-    return safe_runtime_call([&] { delete training_data; });
+    return runtime_error_wrapper([&] { delete training_data; });
 }
 
 Status
 LeanVecTrainingData::load(LeanVecTrainingData** training_data, std::istream& in) noexcept {
-    return safe_runtime_call([&] {
+    return runtime_error_wrapper([&] {
         *training_data = new LeanVecTrainingDataManager{LeanVecTrainingDataImpl::load(in)};
     });
 }

--- a/bindings/cpp/src/training_impl.h
+++ b/bindings/cpp/src/training_impl.h
@@ -84,10 +84,7 @@ struct LeanVecTrainingDataManager : public svs::runtime::LeanVecTrainingData {
         : impl_{std::move(impl)} {}
 
     Status save(std::ostream& out) const noexcept override {
-        SVS_RUNTIME_TRY_BEGIN
-        impl_.save(out);
-        return Status_Ok;
-        SVS_RUNTIME_TRY_END
+        return runtime_error_wrapper([&] { impl_.save(out); });
     }
 
     LeanVecTrainingDataImpl impl_;


### PR DESCRIPTION
I think this produces more readable code. And since `runtime_error_wrapper()` is an internal function, there shouldn't be any disadvantages for the shared lib.