### PR TITLE
Maintain MutableBuffer::best_unvisited_ invariant in sort()

### DIFF
--- a/include/svs/index/vamana/dynamic_search_buffer.h
+++ b/include/svs/index/vamana/dynamic_search_buffer.h
@@ -498,6 +498,16 @@ template <typename Idx, typename Cmp = std::less<>> class MutableBuffer {
             }
         }
 
+        // TODO: Switch over to using iterators for the return values to avoid this.
+        // Maintain best_unvisited_ invariant
+        // cleanup() and std::sort() may invalidate best_unvisited_.
+        // so, have to lookup the next unvisited from scratch.
+        for (best_unvisited_ = 0; best_unvisited_ < roi_end_; ++best_unvisited_) {
+            if (!candidates_[best_unvisited_].visited()) {
+                break;
+            }
+        }
+
         // Check if invariant 6 is active.
         // If so, drop invalid elements off the end until a valid element is found.
         if (slack() == 0) {


### PR DESCRIPTION
If DynamicVamana index contains vectors which are "marked-as-deleted", dynamic search buffer `cleanup()`  call invalidates the `best_unvisited_` invariant which prevents proper usage in `BatchIterator`.

This PR restores the invariant inside the `sort()` call.
