### PR TITLE
fix: Python default VamanaBuildParameters

### DIFF
--- a/bindings/python/src/vamana.cpp
+++ b/bindings/python/src/vamana.cpp
@@ -414,6 +414,7 @@ void wrap(py::module& m) {
         m, "VamanaBuildParameters", "Build parameters for Vamana index construction."
     );
 
+    svs::index::vamana::VamanaBuildParameters default_parameters;
     parameters
         .def(
             py::init([](float alpha,
@@ -430,13 +431,12 @@ void wrap(py::module& m) {
                     prune_to,
                     use_full_search_history};
             }),
-            py::arg("alpha") = svs::FLOAT_PLACEHOLDER,
-            py::arg("graph_max_degree") = svs::VAMANA_GRAPH_MAX_DEGREE_DEFAULT,
-            py::arg("window_size") = svs::VAMANA_WINDOW_SIZE_DEFAULT,
-            py::arg("max_candidate_pool_size") = svs::UNSIGNED_INTEGER_PLACEHOLDER,
-            py::arg("prune_to") = svs::UNSIGNED_INTEGER_PLACEHOLDER,
-            py::arg("use_full_search_history") =
-                svs::VAMANA_USE_FULL_SEARCH_HISTORY_DEFAULT,
+            py::arg("alpha") = default_parameters.alpha,
+            py::arg("graph_max_degree") = default_parameters.graph_max_degree,
+            py::arg("window_size") = default_parameters.window_size,
+            py::arg("max_candidate_pool_size") = default_parameters.max_candidate_pool_size,
+            py::arg("prune_to") = default_parameters.prune_to,
+            py::arg("use_full_search_history") = default_parameters.use_full_search_history,
             R"(
             Construct a new instance from keyword arguments.
 

--- a/bindings/python/tests/test_vamana.py
+++ b/bindings/python/tests/test_vamana.py
@@ -378,3 +378,23 @@ class VamanaTester(unittest.TestCase):
         self._test_build(loader, svs.DistanceType.L2, matcher)
         self._test_build(loader, svs.DistanceType.MIP, matcher)
         self._test_build(loader, svs.DistanceType.Cosine, matcher)
+
+    def test_vamana_build_parameters(self):
+        """Test VamanaBuildParameters construction and member accessors."""
+
+        params = svs.VamanaBuildParameters(
+            alpha = 1.5,
+            graph_max_degree = 64,
+            prune_to = 32,
+            window_size = 128,
+            max_candidate_pool_size = 256
+        )
+
+        self.assertEqual(params.alpha, 1.5)
+        self.assertEqual(params.graph_max_degree, 64)
+        self.assertEqual(params.prune_to, 32)
+        self.assertEqual(params.window_size, 128)
+        self.assertEqual(params.max_candidate_pool_size, 256)
+
+        # Test instatiation with default parameter values
+        params = svs.VamanaBuildParameters()

--- a/include/svs/lib/preprocessor.h
+++ b/include/svs/lib/preprocessor.h
@@ -176,8 +176,8 @@ namespace svs {
 // Maximum values used as default initializers
 inline constexpr size_t UNSIGNED_INTEGER_PLACEHOLDER = std::numeric_limits<size_t>::max();
 inline constexpr float FLOAT_PLACEHOLDER = std::numeric_limits<float>::max();
-inline constexpr float VAMANA_GRAPH_MAX_DEGREE_DEFAULT = 32;
-inline constexpr float VAMANA_WINDOW_SIZE_DEFAULT = 200;
+inline constexpr size_t VAMANA_GRAPH_MAX_DEGREE_DEFAULT = 32;
+inline constexpr size_t VAMANA_WINDOW_SIZE_DEFAULT = 200;
 inline constexpr bool VAMANA_USE_FULL_SEARCH_HISTORY_DEFAULT = true;
 inline constexpr float VAMANA_ALPHA_MINIMIZE_DEFAULT = 1.2;
 inline constexpr float VAMANA_ALPHA_MAXIMIZE_DEFAULT = 0.95;

--- a/tests/svs/index/vamana/build_parameters.cpp
+++ b/tests/svs/index/vamana/build_parameters.cpp
@@ -42,6 +42,16 @@ window_size = 200
 
 CATCH_TEST_CASE("VamanaBuildParameters", "[index][vamana]") {
     CATCH_SECTION("Constructors") {
+        svs::index::vamana::VamanaBuildParameters empty;
+        CATCH_REQUIRE(empty.alpha == svs::FLOAT_PLACEHOLDER);
+        CATCH_REQUIRE(empty.graph_max_degree == svs::VAMANA_GRAPH_MAX_DEGREE_DEFAULT);
+        CATCH_REQUIRE(empty.window_size == svs::VAMANA_WINDOW_SIZE_DEFAULT);
+        CATCH_REQUIRE(empty.max_candidate_pool_size == svs::UNSIGNED_INTEGER_PLACEHOLDER);
+        CATCH_REQUIRE(empty.prune_to == svs::UNSIGNED_INTEGER_PLACEHOLDER);
+        CATCH_REQUIRE(
+            empty.use_full_search_history == svs::VAMANA_USE_FULL_SEARCH_HISTORY_DEFAULT
+        );
+
         auto p = svs::index::vamana::VamanaBuildParameters{1.2f, 64, 128, 750, 60, true};
         CATCH_REQUIRE(p.alpha == 1.2f);
         CATCH_REQUIRE(p.graph_max_degree == 64);


### PR DESCRIPTION
Python default build parameters were not usable because of a type mismatch (pybind11 does not automatically convert float to size_t).

Also use a C++ VamanaBuildParameters instance to set Python defaults instead of repeating the default constants.

Finally, add an extra C++ test to catch inadvertent default constructor changes.