### PR TITLE
fix(search-buffer): ASan heap-buffer-underflow in SearchBuffer::can_skip

### DIFF
--- a/include/svs/index/vamana/search_buffer.h
+++ b/include/svs/index/vamana/search_buffer.h
@@ -340,7 +340,7 @@ template <typename Idx, typename Cmp = std::less<>> class SearchBuffer {
     /// returns ``true``.
     ///
     bool can_skip(float distance) const {
-        return compare_(back().distance(), distance) && full();
+        return full() && (capacity() == 0 || compare_(back().distance(), distance));
     }
 
     ///


### PR DESCRIPTION
ASan will be added in #239. It flags `SearchBuffer::can_skip`. Here we reorder the logic to check `full()` before accessing `back()`. Accessing `back()` on an empty buffer caused an index underflow (`SIZE_MAX`).