### PR TITLE
Add all C++ index properties to Python

### DIFF
--- a/bindings/python/src/dynamic_vamana.cpp
+++ b/bindings/python/src/dynamic_vamana.cpp
@@ -210,6 +210,50 @@ void add_points_specialization(py::class_<svs::DynamicVamana>& index) {
     );
 }
 
+void add_dynamic_vamana_properties(py::class_<svs::DynamicVamana>& vamana) {
+    vamana.def_property(
+        "alpha",
+        &svs::DynamicVamana::get_alpha,
+        &svs::DynamicVamana::set_alpha,
+        "Read/Write (float): Get/set the alpha value used when adding and deleting points."
+    );
+
+    vamana.def_property_readonly(
+        "graph_max_degree",
+        &svs::DynamicVamana::get_graph_max_degree,
+        "Read-only (int): Get the maximum degree of the graph."
+    );
+
+    vamana.def_property(
+        "construction_window_size",
+        &svs::DynamicVamana::get_construction_window_size,
+        &svs::DynamicVamana::set_construction_window_size,
+        "Read/Write (int): Get/set the window size used when adding and deleting points."
+    );
+
+    vamana.def_property(
+        "max_candidates",
+        &svs::DynamicVamana::get_max_candidates,
+        &svs::DynamicVamana::set_max_candidates,
+        "Read/Write (int): Get/set the maximum number of candidates used when adding and "
+        "deleting points."
+    );
+
+    vamana.def_property(
+        "prune_to",
+        &svs::DynamicVamana::get_prune_to,
+        &svs::DynamicVamana::set_prune_to,
+        "Read/Write (int): Get/set the target degree after pruning."
+    );
+
+    vamana.def_property(
+        "full_search_history",
+        &svs::DynamicVamana::get_full_search_history,
+        &svs::DynamicVamana::set_full_search_history,
+        "Read/Write (bool): Get/set whether full search history is recorded."
+    );
+}
+
 ///// Docstrings
 // Put docstrings heere to hopefully make the implementation of `wrap` a bit less
 // cluttered.
@@ -335,20 +379,7 @@ void wrap(py::module& m) {
     // Vamana specific extensions.
     vamana::add_interface(vamana);
 
-    // Dynamic interface.
-    vamana.def_property(
-        "alpha",
-        &svs::DynamicVamana::get_alpha,
-        &svs::DynamicVamana::set_alpha,
-        "Read/Write (float): Get/set the alpha value used when adding and deleting points."
-    );
-
-    vamana.def_property(
-        "construction_window_size",
-        &svs::DynamicVamana::get_construction_window_size,
-        &svs::DynamicVamana::set_construction_window_size,
-        "Read/Write (int): Get/set the window size used when adding and deleting points."
-    );
+    add_dynamic_vamana_properties(vamana);
 
     vamana.def("consolidate", &svs::DynamicVamana::consolidate, CONSOLIDATE_DOCSTRING);
     vamana.def("compact", &svs::DynamicVamana::compact, COMPACT_DOCSTRING);

--- a/bindings/python/src/vamana.cpp
+++ b/bindings/python/src/vamana.cpp
@@ -404,6 +404,50 @@ Method {}:
     );
 }
 
+void add_vamana_properties(py::class_<svs::Vamana>& vamana) {
+    // Vamana properties (mirrors VamanaInterface).
+    vamana.def_property(
+        "alpha",
+        &svs::Vamana::get_alpha,
+        &svs::Vamana::set_alpha,
+        "Read/Write (float): Get/set the alpha value."
+    );
+
+    vamana.def_property_readonly(
+        "graph_max_degree",
+        &svs::Vamana::get_graph_max_degree,
+        "Read-only (int): Get the maximum degree of the graph."
+    );
+
+    vamana.def_property(
+        "construction_window_size",
+        &svs::Vamana::get_construction_window_size,
+        &svs::Vamana::set_construction_window_size,
+        "Read/Write (int): Get/set the construction window size."
+    );
+
+    vamana.def_property(
+        "max_candidates",
+        &svs::Vamana::get_max_candidates,
+        &svs::Vamana::set_max_candidates,
+        "Read/Write (int): Get/set the maximum number of candidates."
+    );
+
+    vamana.def_property(
+        "prune_to",
+        &svs::Vamana::get_prune_to,
+        &svs::Vamana::set_prune_to,
+        "Read/Write (int): Get/set the target degree after pruning."
+    );
+
+    vamana.def_property(
+        "full_search_history",
+        &svs::Vamana::get_full_search_history,
+        &svs::Vamana::set_full_search_history,
+        "Read/Write (bool): Get/set whether full search history is recorded."
+    );
+}
+
 } // namespace detail
 
 void wrap(py::module& m) {
@@ -506,6 +550,8 @@ void wrap(py::module& m) {
 
     // Vamana Specific Extensions.
     add_interface(vamana);
+
+    detail::add_vamana_properties(vamana);
 
     // Reconstruction.
     add_reconstruct_interface(vamana);


### PR DESCRIPTION
Aside from API equivalence, these properties are useful for retrieving build parameters set implicitly by SVS, not passed explicitly by the user. For example, we need them in benchmarking to check the index was built with the expected parameters.