### PR TITLE
fix(mkl): update functions and fix dependency

### DIFF
--- a/cmake/mkl.cmake
+++ b/cmake/mkl.cmake
@@ -64,6 +64,7 @@ if (SVS_EXPERIMENTAL_BUILD_CUSTOM_MKL)
             "export=${mkl_functions_file}"
             "MKLROOT=${MKL_ROOT}"
             "name=${CMAKE_CURRENT_BINARY_DIR}/${SVS_MKL_CUSTOM_LIBRARY_NAME}"
+        DEPENDS ${mkl_functions_file}
     )
 
     # Create a target for the newly created shared object.

--- a/cmake/mkl_functions
+++ b/cmake/mkl_functions
@@ -1,4 +1,5 @@
 cblas_sgemm
+cblas_saxpby
 mkl_simatcopy
 LAPACKE_sgesvd
 mkl_get_max_threads

--- a/cmake/mkl_functions_ivf
+++ b/cmake/mkl_functions_ivf
@@ -1,4 +1,5 @@
 cblas_sgemm
+cblas_saxpby
 mkl_simatcopy
 LAPACKE_sgesvd
 mkl_get_max_threads


### PR DESCRIPTION
We need `cblas_saxpby` for OOD. Additionally added `DEPENDS ${mkl_functions_file}` to trigger rebuilding our MKL lib when the functions files change.