### PR TITLE
Native serialization for MutableVamana index

### DIFF
--- a/include/svs/core/graph/graph.h
+++ b/include/svs/core/graph/graph.h
@@ -354,14 +354,18 @@ template <std::unsigned_integral Idx, data::MemoryDataset Data> class SimpleGrap
         size_t num_vertices = lib::load_at<size_t>(table, "num_vertices");
         size_t max_degree = lib::load_at<size_t>(table, "max_degree");
 
-        // Skip legacy stream metadata (no-op for native serialization).
-        deserializer.read_name(is);
-        deserializer.read_size(is);
-        deserializer.read_binary<io::v1::Header>(is);
+        // Build a table compatible with GenericSerializer
+        auto data_table = toml::table{
+            {lib::config_schema_key, data::GenericSerializer::serialization_schema},
+            {lib::config_version_key, data::GenericSerializer::save_version.str()},
+            {"eltype", lib::save(datatype_v<Idx>)},
+            {"num_vectors", lib::save(num_vertices)},
+            {"dims", lib::save(max_degree + 1)},
+        };
 
-        auto data = data_type(num_vertices, max_degree + 1, alloc_args...);
-        io::populate(is, data);
-        return lazy(std::move(data));
+        return lazy(data_type::load(
+            lib::ContextFreeLoadTable(data_table), deserializer, is, alloc_args...
+        ));
     }
 
   protected:
@@ -471,12 +475,27 @@ class SimpleBlockedGraph
         return parent_type::load(table, lazy);
     }
 
+    static constexpr SimpleBlockedGraph load(
+        const lib::ContextFreeLoadTable& table,
+        const lib::detail::Deserializer& deserializer,
+        std::istream& is
+    ) {
+        auto lazy =
+            lib::Lazy([](data_type data) { return SimpleBlockedGraph(std::move(data)); });
+        return parent_type::load(table, lazy, deserializer, is);
+    }
+
     static constexpr SimpleBlockedGraph load(const std::filesystem::path& path) {
         if (data::detail::is_likely_reload(path)) {
             return lib::load_from_disk<SimpleBlockedGraph>(path);
         } else {
             return SimpleBlockedGraph(data_type::load(path));
         }
+    }
+
+    static constexpr SimpleBlockedGraph
+    load(const lib::detail::Deserializer& deserializer, std::istream& is) {
+        return lib::load_from_stream<SimpleBlockedGraph>(deserializer, is);
     }
 };
 

--- a/include/svs/core/translation.h
+++ b/include/svs/core/translation.h
@@ -380,17 +380,16 @@ class IDTranslator {
         return translator;
     }
 
-    static IDTranslator
-    load(const lib::detail::Deserializer& deserializer, std::istream& is) {
-        auto table = lib::detail::read_metadata(deserializer, is);
-        auto translation = table.template cast<toml::table>()
-                               .at("translation")
-                               .template cast<toml::table>();
-        IDTranslator::validate(translation);
+    static IDTranslator load(
+        const lib::ContextFreeLoadTable& table,
+        const lib::detail::Deserializer& deserializer,
+        std::istream& is
+    ) {
+        IDTranslator::validate(table);
         deserializer.read_name(is);
         deserializer.read_size(is);
 
-        return IDTranslator::load(translation, is);
+        return IDTranslator::load(table, is);
     }
 
     static IDTranslator load(const lib::LoadTable& table) {

--- a/include/svs/index/flat/dynamic_flat.h
+++ b/include/svs/index/flat/dynamic_flat.h
@@ -804,7 +804,13 @@ auto auto_dynamic_assemble(
     svs::logging::logger_ptr logger = svs::logging::get()
 ) {
     using Data = decltype(data_loader());
-    auto config_loader = [&] { return IDTranslator::load(deserializer, is); };
+    auto config_loader = [&] {
+        auto table = lib::detail::read_metadata(deserializer, is);
+        auto translation = table.template cast<toml::table>()
+                               .at("translation")
+                               .template cast<toml::table>();
+        return IDTranslator::load(translation, deserializer, is);
+    };
 
     std::optional<IDTranslator> config;
     std::optional<Data> data;

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -1456,4 +1456,92 @@ auto auto_dynamic_assemble(
         std::move(logger)};
 }
 
+template <
+    typename LazyGraphLoader,
+    typename LazyDataLoader,
+    typename Distance,
+    typename ThreadPoolProto>
+auto auto_dynamic_assemble(
+    const lib::detail::Deserializer& deserializer,
+    std::istream& is,
+    LazyGraphLoader graph_loader,
+    LazyDataLoader data_loader,
+    Distance distance,
+    ThreadPoolProto threadpool_proto,
+    bool SVS_UNUSED(debug_load_from_static) = false,
+    svs::logging::logger_ptr logger = svs::logging::get()
+) {
+    using Data = decltype(data_loader());
+    using Graph = decltype(graph_loader());
+
+    // The config loader reads the combined TOML (parameters + translation)
+    // and the translator binary data.
+    auto config_loader = [&]() -> detail::VamanaStateLoader {
+        auto table = lib::detail::read_metadata(deserializer, is);
+
+        auto parameters = lib::load<VamanaIndexParameters>(
+            table.template cast<toml::table>().at("parameters").template cast<toml::table>()
+        );
+
+        auto translation = table.template cast<toml::table>()
+                               .at("translation")
+                               .template cast<toml::table>();
+
+        auto translator = IDTranslator::load(translation, deserializer, is);
+
+        return detail::VamanaStateLoader{std::move(parameters), std::move(translator)};
+    };
+
+    std::optional<detail::VamanaStateLoader> config;
+    std::optional<Data> data;
+    std::optional<Graph> graph;
+
+    if (deserializer.is_native()) {
+        // Order is always config->data->graph.
+        config.emplace(config_loader());
+        data.emplace(data_loader());
+        graph.emplace(graph_loader());
+    } else {
+        // Directory packing order is filesystem-dependent.
+        // Read 3 data blocks: config, data and graph in a corresponding order.
+        for (int data_block_idx = 0; data_block_idx < 3; ++data_block_idx) {
+            auto name = deserializer.read_name_in_advance(is);
+            if (name.starts_with("config/")) {
+                config.emplace(config_loader());
+            } else if (name.starts_with("data/")) {
+                data.emplace(data_loader());
+            } else if (name.starts_with("graph/")) {
+                graph.emplace(graph_loader());
+            } else {
+                throw ANNEXCEPTION("The stream is corrupted!");
+            }
+        }
+    }
+
+    auto datasize = data->size();
+    auto graphsize = graph->n_nodes();
+    if (datasize != graphsize) {
+        throw ANNEXCEPTION(
+            "Reloaded data has {} nodes while the graph has {} nodes!", datasize, graphsize
+        );
+    }
+
+    auto translator_size = config->translator_.size();
+    if (translator_size != datasize) {
+        throw ANNEXCEPTION(
+            "Translator has {} IDs but should have {}", translator_size, datasize
+        );
+    }
+
+    auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
+    return MutableVamanaIndex{
+        config->parameters_,
+        std::move(*data),
+        std::move(*graph),
+        std::move(distance),
+        std::move(config->translator_),
+        std::move(threadpool),
+        std::move(logger)};
+}
+
 } // namespace svs::index::vamana

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -355,33 +355,49 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         ThreadPoolProto threadpool_proto,
         DataLoaderArgs&&... data_args
     ) {
-        namespace fs = std::filesystem;
-        lib::UniqueTempDirectory tempdir{"svs_vamana_load"};
-        lib::DirectoryArchiver::unpack(stream, tempdir);
-
-        const auto config_path = tempdir.get() / "config";
-        if (!fs::is_directory(config_path)) {
-            throw ANNEXCEPTION("Invalid Vamana index archive: missing config directory!");
+        auto deserializer = svs::lib::detail::Deserializer::build(stream);
+        auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
+        using GraphType = svs::GraphLoader<>::return_type;
+        if constexpr (std::is_same_v<std::decay_t<Distance>, DistanceType>) {
+            auto dispatcher = DistanceDispatcher(distance);
+            return dispatcher([&](auto distance_function) {
+                return make_dynamic_vamana<manager::as_typelist<QueryTypes>>(
+                    index::vamana::auto_dynamic_assemble(
+                        deserializer,
+                        stream,
+                        // lazy graph loader
+                        [&]() -> GraphType {
+                            return GraphType::load(deserializer, stream);
+                        },
+                        // lazy data loader
+                        [&]() -> Data {
+                            return lib::load_from_stream<Data>(
+                                deserializer, stream, SVS_FWD(data_args)...
+                            );
+                        },
+                        distance_function,
+                        std::move(threadpool)
+                    )
+                );
+            });
+        } else {
+            return make_dynamic_vamana<manager::as_typelist<QueryTypes>>(
+                index::vamana::auto_dynamic_assemble(
+                    deserializer,
+                    stream,
+                    // lazy graph loader
+                    [&]() -> GraphType { return GraphType::load(deserializer, stream); },
+                    // lazy data loader
+                    [&]() -> Data {
+                        return lib::load_from_stream<Data>(
+                            deserializer, stream, SVS_FWD(data_args)...
+                        );
+                    },
+                    distance,
+                    std::move(threadpool)
+                )
+            );
         }
-
-        const auto graph_path = tempdir.get() / "graph";
-        if (!fs::is_directory(graph_path)) {
-            throw ANNEXCEPTION("Invalid Vamana index archive: missing graph directory!");
-        }
-
-        const auto data_path = tempdir.get() / "data";
-        if (!fs::is_directory(data_path)) {
-            throw ANNEXCEPTION("Invalid Vamana index archive: missing data directory!");
-        }
-
-        return assemble<QueryTypes>(
-            config_path,
-            svs::GraphLoader{graph_path},
-            lib::load_from_disk<Data>(data_path, SVS_FWD(data_args)...),
-            distance,
-            threads::as_threadpool(std::move(threadpool_proto)),
-            false
-        );
     }
 
     /// @copydoc svs::Vamana::batch_iterator

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,7 +148,7 @@ set(TEST_SOURCES
     # Global scalar quantization
     ${TEST_DIR}/svs/quantization/scalar/scalar.cpp
 
-    # # ${TEST_DIR}/svs/index/vamana/dynamic_index.cpp
+    ${TEST_DIR}/svs/index/vamana/dynamic_index.cpp
 )
 
 #####

--- a/tests/svs/index/vamana/dynamic_index.cpp
+++ b/tests/svs/index/vamana/dynamic_index.cpp
@@ -23,6 +23,8 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <numeric>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -32,11 +34,14 @@
 
 // catch2
 #include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_approx.hpp>
 
 // tests
 #include "tests/utils/test_dataset.h"
 #include "tests/utils/utils.h"
 
+// The MutableVamanaIndex "Soft Deletion" test uses outdated API.
+#if 0
 namespace {
 template <typename T> auto copy_dataset(const T& data) {
     auto copy = svs::data::SimplePolymorphicData<typename T::element_type, T::extent>{
@@ -244,5 +249,141 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
         auto post_reinsertion_recall = svs::k_recall_at_n(groundtruth, results);
         std::cout << "Post reinsertion recall: " << post_reinsertion_recall << " in "
                   << post_add_time << " seconds." << std::endl;
+    }
+}
+#endif
+
+CATCH_TEST_CASE(
+    "MutableVamana Index Save and Load", "[graph_index][dynamic_index][saveload]"
+) {
+    const size_t num_threads = 2;
+    using Distance = svs::distance::DistanceL2;
+
+    auto data = test_dataset::data_blocked_f32();
+    std::vector<size_t> indices(data.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    svs::index::vamana::VamanaBuildParameters parameters{1.2, 64, 10, 20, 10, true};
+    auto index = svs::index::vamana::MutableVamanaIndex(
+        parameters, std::move(data), indices, Distance(), num_threads
+    );
+
+    const size_t num_neighbors = 10;
+    auto queries = test_dataset::queries();
+    auto search_params = svs::index::vamana::VamanaSearchParameters{};
+    search_params.buffer_config_ = svs::index::vamana::SearchBufferConfig{num_neighbors};
+    auto results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+    index.search(results.view(), queries.cview(), search_params);
+
+    CATCH_SECTION("Load MutableVamana Index being serialized natively to stream") {
+        std::stringstream stream;
+        index.save(stream);
+        {
+            auto deserializer = svs::lib::detail::Deserializer::build(stream);
+
+            using Data_t = svs::data::BlockedData<float>;
+            using GraphType = svs::graphs::SimpleBlockedGraph<uint32_t>;
+
+            auto loaded = svs::index::vamana::auto_dynamic_assemble(
+                deserializer,
+                stream,
+                // lazy graph loader
+                [&]() -> GraphType { return GraphType::load(deserializer, stream); },
+                // lazy data loader
+                [&]() -> Data_t {
+                    return svs::lib::load_from_stream<Data_t>(deserializer, stream);
+                },
+                Distance(),
+                num_threads
+            );
+
+            CATCH_REQUIRE(loaded.size() == index.size());
+            CATCH_REQUIRE(loaded.dimensions() == index.dimensions());
+            CATCH_REQUIRE(loaded.get_alpha() == index.get_alpha());
+            CATCH_REQUIRE(loaded.get_graph_max_degree() == index.get_graph_max_degree());
+            CATCH_REQUIRE(loaded.get_max_candidates() == index.get_max_candidates());
+            CATCH_REQUIRE(
+                loaded.get_construction_window_size() ==
+                index.get_construction_window_size()
+            );
+            CATCH_REQUIRE(loaded.get_prune_to() == index.get_prune_to());
+            CATCH_REQUIRE(
+                loaded.get_full_search_history() == index.get_full_search_history()
+            );
+            index.on_ids([&](size_t e) { CATCH_REQUIRE(loaded.has_id(e)); });
+
+            auto loaded_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+            loaded.search(loaded_results.view(), queries.cview(), search_params);
+            for (size_t q = 0; q < queries.size(); ++q) {
+                for (size_t i = 0; i < num_neighbors; ++i) {
+                    CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                    CATCH_REQUIRE(
+                        loaded_results.distance(q, i) ==
+                        Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                    );
+                }
+            }
+        }
+    }
+
+    CATCH_SECTION("Load MutableVamana Index being serialized with intermediate files") {
+        std::stringstream stream;
+        {
+            svs::lib::UniqueTempDirectory tempdir{"svs_dynvamana_save"};
+            const auto config_dir = tempdir.get() / "config";
+            const auto graph_dir = tempdir.get() / "graph";
+            const auto data_dir = tempdir.get() / "data";
+            std::filesystem::create_directories(config_dir);
+            std::filesystem::create_directories(graph_dir);
+            std::filesystem::create_directories(data_dir);
+            index.save(config_dir, graph_dir, data_dir);
+            svs::lib::DirectoryArchiver::pack(tempdir, stream);
+        }
+        {
+            auto deserializer = svs::lib::detail::Deserializer::build(stream);
+
+            using Data_t = svs::data::BlockedData<float>;
+            using GraphType = svs::graphs::SimpleBlockedGraph<uint32_t>;
+
+            auto loaded = svs::index::vamana::auto_dynamic_assemble(
+                deserializer,
+                stream,
+                // lazy graph loader
+                [&]() -> GraphType { return GraphType::load(deserializer, stream); },
+                // lazy data loader
+                [&]() -> Data_t {
+                    return svs::lib::load_from_stream<Data_t>(deserializer, stream);
+                },
+                Distance(),
+                num_threads
+            );
+
+            CATCH_REQUIRE(loaded.size() == index.size());
+            CATCH_REQUIRE(loaded.dimensions() == index.dimensions());
+            CATCH_REQUIRE(loaded.get_alpha() == index.get_alpha());
+            CATCH_REQUIRE(loaded.get_graph_max_degree() == index.get_graph_max_degree());
+            CATCH_REQUIRE(loaded.get_max_candidates() == index.get_max_candidates());
+            CATCH_REQUIRE(
+                loaded.get_construction_window_size() ==
+                index.get_construction_window_size()
+            );
+            CATCH_REQUIRE(loaded.get_prune_to() == index.get_prune_to());
+            CATCH_REQUIRE(
+                loaded.get_full_search_history() == index.get_full_search_history()
+            );
+            index.on_ids([&](size_t e) { CATCH_REQUIRE(loaded.has_id(e)); });
+
+            auto loaded_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+            loaded.search(loaded_results.view(), queries.cview(), search_params);
+            for (size_t q = 0; q < queries.size(); ++q) {
+                for (size_t i = 0; i < num_neighbors; ++i) {
+                    CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                    CATCH_REQUIRE(
+                        loaded_results.distance(q, i) ==
+                        Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR introduce native serialization for `MutableVamana` index.

Main changes are:

1. New overload of svs::index::vamana::auto_dynamic_assemble required for direct deserialization accepts lazy loaders and call them in a flexible order to cover legacy serialized models.
2. The test file tests/svs/index/vamana/dynamic_index.cpp is returned to the test build, as far as it is the right place for serialization tests.
3. Some minor refactoring to streamline the logic.
