### PR TITLE
feat(ivf): Add Float16 numpy array specializations for IVF/DynamicIVF assembly

### DIFF
--- a/bindings/python/src/dynamic_ivf.cpp
+++ b/bindings/python/src/dynamic_ivf.cpp
@@ -668,7 +668,9 @@ Method {}:
     }
 
     // Assemble from numpy array.
+    add_assemble_from_clustering_array_specialization<svs::Float16>(dynamic_ivf);
     add_assemble_from_clustering_array_specialization<float>(dynamic_ivf);
+    add_assemble_from_file_array_specialization<svs::Float16>(dynamic_ivf);
     add_assemble_from_file_array_specialization<float>(dynamic_ivf);
 
     // Index modification.

--- a/bindings/python/src/ivf.cpp
+++ b/bindings/python/src/ivf.cpp
@@ -784,7 +784,9 @@ void wrap(py::module& m) {
     detail::wrap_assemble(ivf);
 
     // Assemble from numpy array.
+    detail::add_assemble_from_clustering_array_specialization<svs::Float16>(ivf);
     detail::add_assemble_from_clustering_array_specialization<float>(ivf);
+    detail::add_assemble_from_file_array_specialization<svs::Float16>(ivf);
     detail::add_assemble_from_file_array_specialization<float>(ivf);
 
     // Make the IVF type searchable.

--- a/bindings/python/tests/test_dynamic_ivf.py
+++ b/bindings/python/tests/test_dynamic_ivf.py
@@ -257,6 +257,25 @@ class DynamicIVFTester(unittest.TestCase):
             print(f"  assemble_from_file numpy recall: {recall2}")
             self.assertTrue(0.5 < recall2 <= 1.0)
 
+        # Test with float16 numpy array
+        data_f16 = data.astype('float16')
+        print("Testing DynamicIVF.assemble_from_clustering with numpy array (float16)")
+        index_f16 = svs.DynamicIVF.assemble_from_clustering(
+            clustering = clustering,
+            py_data = data_f16,
+            ids = ids,
+            distance = svs.DistanceType.L2,
+            num_threads = num_threads,
+        )
+        self.assertEqual(index_f16.size, test_number_of_vectors)
+        self.assertEqual(index_f16.dimensions, test_data_dims)
+
+        index_f16.search_parameters = search_params
+        I_f16, D_f16 = index_f16.search(queries, k)
+        recall_f16 = svs.k_recall_at(groundtruth, I_f16, k, k)
+        print(f"  assemble_from_clustering numpy float16 recall: {recall_f16}")
+        self.assertTrue(0.4 < recall_f16 <= 1.0)
+
     def test_build_from_loader(self):
         """Test building DynamicIVF using a VectorDataLoader and explicit IDs."""
         num_threads = 2

--- a/bindings/python/tests/test_ivf.py
+++ b/bindings/python/tests/test_ivf.py
@@ -404,6 +404,24 @@ class IVFTester(unittest.TestCase):
             print(f"  assemble_from_file numpy recall: {recall2}")
             self.assertTrue(0.5 < recall2 <= 1.0)
 
+        # Test with float16 numpy array
+        data_f16 = data.astype('float16')
+        print("Testing IVF.assemble_from_clustering with numpy array (float16)")
+        ivf_f16 = svs.IVF.assemble_from_clustering(
+            clustering = clustering,
+            py_data = data_f16,
+            distance = svs.DistanceType.L2,
+            num_threads = num_threads,
+        )
+        self.assertEqual(ivf_f16.size, test_number_of_vectors)
+        self.assertEqual(ivf_f16.dimensions, test_dimensions)
+
+        ivf_f16.search_parameters = search_params
+        I_f16, D_f16 = ivf_f16.search(queries, k)
+        recall_f16 = svs.k_recall_at(groundtruth, I_f16, k, k)
+        print(f"  assemble_from_clustering numpy float16 recall: {recall_f16}")
+        self.assertTrue(0.4 < recall_f16 <= 1.0)
+
     def test_build(self):
         # Build directly from data
         data = svs.read_vecs(test_data_vecs)


### PR DESCRIPTION

Register Float16 pybind specializations for numpy array assembly paths. Previously only float32 was registered for the numpy array overloads of assemble_from_clustering and assemble_from_file in both IVF and DynamicIVF.

Added:
- add_assemble_from_clustering_array_specialization<svs::Float16>
- add_assemble_from_file_array_specialization<svs::Float16>