### PR TITLE
[CPP Runtime] Refactor storage tags and add static Vamana index support

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -102,7 +102,9 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
             svs::svs
             svs_compile_options
         )
-        link_mkl_static(${TARGET_NAME})
+        if(SVS_EXPERIMENTAL_LINK_STATIC_MKL)
+            link_mkl_static(${TARGET_NAME})
+        endif()
         if(SVS_LVQ_HEADER)
             target_compile_definitions(${TARGET_NAME} PRIVATE
                 SVS_LVQ_HEADER="${SVS_LVQ_HEADER}"

--- a/bindings/cpp/include/svs/runtime/dynamic_vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/dynamic_vamana_index.h
@@ -74,6 +74,14 @@ struct SVS_RUNTIME_API DynamicVamanaIndex : public VamanaIndex {
     ) noexcept;
 
     virtual size_t blocksize_bytes() const noexcept = 0;
+
+    // Override for VamanaIndex interface
+    Status add(size_t, const float*) noexcept override {
+        return Status(
+            ErrorCode::NOT_IMPLEMENTED,
+            "Use add(size_t n, const size_t* labels, const float* x) for DynamicVamanaIndex"
+        );
+    }
 };
 
 struct SVS_RUNTIME_API DynamicVamanaIndexLeanVec : public DynamicVamanaIndex {

--- a/bindings/cpp/include/svs/runtime/vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/vamana_index.h
@@ -16,37 +16,47 @@
 
 #pragma once
 #include <svs/runtime/api_defs.h>
+#include <svs/runtime/training.h>
 
 #include <cstddef>
+#include <iosfwd>
 
 namespace svs {
 namespace runtime {
 namespace v0 {
+
+namespace detail {
+struct VamanaBuildParameters {
+    size_t graph_max_degree = Unspecify<size_t>();
+    size_t prune_to = Unspecify<size_t>();
+    float alpha = Unspecify<float>();
+    size_t construction_window_size = Unspecify<size_t>();
+    size_t max_candidate_pool_size = Unspecify<size_t>();
+    OptionalBool use_full_search_history = Unspecify<bool>();
+};
+
+struct VamanaSearchParameters {
+    size_t search_window_size = Unspecify<size_t>();
+    size_t search_buffer_capacity = Unspecify<size_t>();
+    size_t prefetch_lookahead = Unspecify<size_t>();
+    size_t prefetch_step = Unspecify<size_t>();
+};
+} // namespace detail
 
 // Abstract interface for Vamana-based indices.
 // NOTE VamanaIndex is not implemented directly, only DynamicVamanaIndex is implemented.
 struct SVS_RUNTIME_API VamanaIndex {
     virtual ~VamanaIndex();
 
-    struct BuildParams {
-        size_t graph_max_degree = Unspecify<size_t>();
-        size_t prune_to = Unspecify<size_t>();
-        float alpha = Unspecify<float>();
-        size_t construction_window_size = Unspecify<size_t>();
-        size_t max_candidate_pool_size = Unspecify<size_t>();
-        OptionalBool use_full_search_history = Unspecify<bool>();
-    };
-
-    struct SearchParams {
-        size_t search_window_size = Unspecify<size_t>();
-        size_t search_buffer_capacity = Unspecify<size_t>();
-        size_t prefetch_lookahead = Unspecify<size_t>();
-        size_t prefetch_step = Unspecify<size_t>();
-    };
+    using BuildParams = detail::VamanaBuildParameters;
+    using SearchParams = detail::VamanaSearchParameters;
 
     struct DynamicIndexParams {
         size_t blocksize_exp = 30;
     };
+
+    virtual Status add(size_t n, const float* x) noexcept = 0;
+    virtual Status reset() noexcept = 0;
 
     virtual Status search(
         size_t n,
@@ -66,6 +76,50 @@ struct SVS_RUNTIME_API VamanaIndex {
         const SearchParams* params = nullptr,
         IDFilter* filter = nullptr
     ) const noexcept = 0;
+
+    // Utility function to check storage kind support
+    static Status check_storage_kind(StorageKind storage_kind) noexcept;
+
+    // Static constructors and destructors
+    static Status build(
+        VamanaIndex** index,
+        size_t dim,
+        MetricType metric,
+        StorageKind storage_kind,
+        const VamanaIndex::BuildParams& params = VamanaIndex::BuildParams{},
+        const VamanaIndex::SearchParams& default_search_params = VamanaIndex::SearchParams{}
+    ) noexcept;
+
+    static Status destroy(VamanaIndex* index) noexcept;
+
+    virtual Status save(std::ostream& out) const noexcept = 0;
+    static Status load(
+        VamanaIndex** index, std::istream& in, MetricType metric, StorageKind storage_kind
+    ) noexcept;
+};
+
+struct SVS_RUNTIME_API VamanaIndexLeanVec : public VamanaIndex {
+    // Specialization to build LeanVec-based Vamana index with specified leanvec dims
+    static Status build(
+        VamanaIndex** index,
+        size_t dim,
+        MetricType metric,
+        StorageKind storage_kind,
+        size_t leanvec_dims,
+        const VamanaIndex::BuildParams& params = {},
+        const VamanaIndex::SearchParams& default_search_params = {}
+    ) noexcept;
+
+    // Specialization to build LeanVec-based Vamana index with provided training data
+    static Status build(
+        VamanaIndex** index,
+        size_t dim,
+        MetricType metric,
+        StorageKind storage_kind,
+        const LeanVecTrainingData* training_data,
+        const VamanaIndex::BuildParams& params = {},
+        const VamanaIndex::SearchParams& default_search_params = {}
+    ) noexcept;
 };
 
 } // namespace v0

--- a/bindings/cpp/include/svs/runtime/vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/vamana_index.h
@@ -44,7 +44,6 @@ struct VamanaSearchParameters {
 } // namespace detail
 
 // Abstract interface for Vamana-based indices.
-// NOTE VamanaIndex is not implemented directly, only DynamicVamanaIndex is implemented.
 struct SVS_RUNTIME_API VamanaIndex {
     virtual ~VamanaIndex();
 

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -23,6 +23,8 @@ namespace runtime {
 
 // Dynamic IVF index implementation (non-LeanVec storage kinds)
 class DynamicIVFIndexImpl {
+    using allocator_type = svs::data::Blocked<svs::lib::Allocator<float>>;
+
   public:
     DynamicIVFIndexImpl(
         size_t dim,
@@ -184,25 +186,32 @@ class DynamicIVFIndexImpl {
         }
 
         // Dispatch on storage kind to load with correct data type
-        return ivf_storage::dispatch_ivf_storage_kind(storage_kind, [&](auto tag) {
-            using Tag = decltype(tag);
-            using DataType = ivf_storage::IVFBlockedStorageType_t<Tag>;
+        return ivf_storage::dispatch_ivf_storage_kind<allocator_type>(
+            storage_kind,
+            [&](auto tag) {
+                using Tag = decltype(tag);
+                using DataType = typename Tag::type;
 
-            svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
-            return distance_dispatcher([&](auto&& distance) {
-                auto impl = std::make_unique<svs::DynamicIVF>(
-                    svs::DynamicIVF::assemble<float, svs::BFloat16, DataType>(
-                        in,
-                        std::forward<decltype(distance)>(distance),
+                svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
+                return distance_dispatcher([&](auto&& distance) {
+                    auto impl = std::make_unique<svs::DynamicIVF>(
+                        svs::DynamicIVF::assemble<float, svs::BFloat16, DataType>(
+                            in,
+                            std::forward<decltype(distance)>(distance),
+                            num_threads,
+                            intra_query_threads
+                        )
+                    );
+                    return new DynamicIVFIndexImpl(
+                        std::move(impl),
+                        metric,
+                        storage_kind,
                         num_threads,
                         intra_query_threads
-                    )
-                );
-                return new DynamicIVFIndexImpl(
-                    std::move(impl), metric, storage_kind, num_threads, intra_query_threads
-                );
-            });
-        });
+                    );
+                });
+            }
+        );
     }
 
   protected:
@@ -297,20 +306,25 @@ class DynamicIVFIndexImpl {
             );
 
             // Dispatch on storage kind to compress and assemble
-            return ivf_storage::dispatch_ivf_storage_kind(storage_kind_, [&](auto tag) {
-                // Compress data to target storage type using the factory
-                auto compressed_data =
-                    ivf_storage::make_ivf_blocked_storage(tag, data, threadpool);
+            return ivf_storage::dispatch_ivf_storage_kind<allocator_type>(
+                storage_kind_,
+                [&](auto tag) {
+                    // Compress data to target storage type using the factory
+                    auto compressed_data =
+                        ivf_storage::make_ivf_blocked_storage(tag, data, threadpool);
 
-                return new svs::DynamicIVF(svs::DynamicIVF::assemble_from_clustering<float>(
-                    std::move(clustering),
-                    std::move(compressed_data),
-                    ids,
-                    std::forward<decltype(distance)>(distance),
-                    num_threads_,
-                    intra_query_threads_
-                ));
-            });
+                    return new svs::DynamicIVF(
+                        svs::DynamicIVF::assemble_from_clustering<float>(
+                            std::move(clustering),
+                            std::move(compressed_data),
+                            ids,
+                            std::forward<decltype(distance)>(distance),
+                            num_threads_,
+                            intra_query_threads_
+                        )
+                    );
+                }
+            );
         }));
     }
 
@@ -328,6 +342,8 @@ class DynamicIVFIndexImpl {
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // Dynamic IVF index implementation for LeanVec storage kinds
 class DynamicIVFIndexLeanVecImpl : public DynamicIVFIndexImpl {
+    using allocator_type = svs::data::Blocked<svs::lib::Allocator<std::byte>>;
+
   public:
     using LeanVecMatricesType = LeanVecTrainingDataImpl::LeanVecMatricesType;
 
@@ -397,25 +413,32 @@ class DynamicIVFIndexLeanVecImpl : public DynamicIVFIndexImpl {
             num_threads = static_cast<size_t>(omp_get_max_threads());
         }
 
-        return ivf_storage::dispatch_ivf_leanvec_storage_kind(storage_kind, [&](auto tag) {
-            using Tag = decltype(tag);
-            using DataType = ivf_storage::IVFBlockedStorageType_t<Tag>;
+        return ivf_storage::dispatch_ivf_leanvec_storage_kind<allocator_type>(
+            storage_kind,
+            [&](auto tag) {
+                using Tag = decltype(tag);
+                using DataType = typename Tag::type;
 
-            svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
-            return distance_dispatcher([&](auto&& distance) {
-                auto impl = std::make_unique<svs::DynamicIVF>(
-                    svs::DynamicIVF::assemble<float, svs::BFloat16, DataType>(
-                        in,
-                        std::forward<decltype(distance)>(distance),
+                svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
+                return distance_dispatcher([&](auto&& distance) {
+                    auto impl = std::make_unique<svs::DynamicIVF>(
+                        svs::DynamicIVF::assemble<float, svs::BFloat16, DataType>(
+                            in,
+                            std::forward<decltype(distance)>(distance),
+                            num_threads,
+                            intra_query_threads
+                        )
+                    );
+                    return new DynamicIVFIndexLeanVecImpl(
+                        std::move(impl),
+                        metric,
+                        storage_kind,
                         num_threads,
                         intra_query_threads
-                    )
-                );
-                return new DynamicIVFIndexLeanVecImpl(
-                    std::move(impl), metric, storage_kind, num_threads, intra_query_threads
-                );
-            });
-        });
+                    );
+                });
+            }
+        );
     }
 
   protected:
@@ -451,7 +474,7 @@ class DynamicIVFIndexLeanVecImpl : public DynamicIVFIndexImpl {
             );
 
             // Dispatch on LeanVec storage kind to compress and assemble
-            return ivf_storage::dispatch_ivf_leanvec_storage_kind(
+            return ivf_storage::dispatch_ivf_leanvec_storage_kind<allocator_type>(
                 storage_kind_,
                 [&](auto tag) {
                     // Compress data to LeanVec storage type using the factory with matrices

--- a/bindings/cpp/src/dynamic_vamana_index_impl.h
+++ b/bindings/cpp/src/dynamic_vamana_index_impl.h
@@ -466,7 +466,7 @@ class DynamicVamanaIndexImpl {
             impl_->get_full_search_history()};
     }
 
-    template <storage::StorageTag Tag>
+    template <typename Tag>
     static svs::DynamicVamana*
     load_impl_t(Tag&& tag, std::istream& stream, MetricType metric) {
         namespace fs = std::filesystem;

--- a/bindings/cpp/src/dynamic_vamana_index_impl.h
+++ b/bindings/cpp/src/dynamic_vamana_index_impl.h
@@ -140,10 +140,9 @@ class DynamicVamanaIndexImpl {
 
                 // Pad results if not enough neighbors found
                 if (found < k) {
-                    auto& dists = result.distances();
-                    std::fill(dists.begin() + found, dists.end(), Unspecify<float>());
-                    auto& inds = result.indices();
-                    std::fill(inds.begin() + found, inds.end(), Unspecify<size_t>());
+                    for (size_t j = found; j < k; ++j) {
+                        result.set(Neighbor{Unspecify<size_t>(), Unspecify<float>()}, i, j);
+                    }
                 }
             }
         };

--- a/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
+++ b/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
@@ -34,6 +34,7 @@ namespace runtime {
 // Vamana index implementation for LeanVec storage kinds
 struct DynamicVamanaIndexLeanVecImpl : public DynamicVamanaIndexImpl {
     using LeanVecMatricesType = LeanVecTrainingDataImpl::LeanVecMatricesType;
+    using allocator_type = svs::data::Blocked<svs::lib::Allocator<std::byte>>;
 
     DynamicVamanaIndexLeanVecImpl(
         std::unique_ptr<svs::DynamicVamana>&& impl,
@@ -81,17 +82,17 @@ struct DynamicVamanaIndexLeanVecImpl : public DynamicVamanaIndexImpl {
         switch (kind) {
             case StorageKind::LeanVec4x4:
                 return f(
-                    storage::StorageKindTag<StorageKind::LeanVec4x4>{},
+                    storage::StorageType<StorageKind::LeanVec4x4, allocator_type>{},
                     std::forward<Args>(args)...
                 );
             case StorageKind::LeanVec4x8:
                 return f(
-                    storage::StorageKindTag<StorageKind::LeanVec4x8>{},
+                    storage::StorageType<StorageKind::LeanVec4x8, allocator_type>{},
                     std::forward<Args>(args)...
                 );
             case StorageKind::LeanVec8x8:
                 return f(
-                    storage::StorageKindTag<StorageKind::LeanVec8x8>{},
+                    storage::StorageType<StorageKind::LeanVec8x8, allocator_type>{},
                     std::forward<Args>(args)...
                 );
             default:

--- a/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
+++ b/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
@@ -80,11 +80,20 @@ struct DynamicVamanaIndexLeanVecImpl : public DynamicVamanaIndexImpl {
     static auto dispatch_leanvec_storage_kind(StorageKind kind, F&& f, Args&&... args) {
         switch (kind) {
             case StorageKind::LeanVec4x4:
-                return f(storage::LeanVec4x4Tag{}, std::forward<Args>(args)...);
+                return f(
+                    storage::StorageKindTag<StorageKind::LeanVec4x4>{},
+                    std::forward<Args>(args)...
+                );
             case StorageKind::LeanVec4x8:
-                return f(storage::LeanVec4x8Tag{}, std::forward<Args>(args)...);
+                return f(
+                    storage::StorageKindTag<StorageKind::LeanVec4x8>{},
+                    std::forward<Args>(args)...
+                );
             case StorageKind::LeanVec8x8:
-                return f(storage::LeanVec8x8Tag{}, std::forward<Args>(args)...);
+                return f(
+                    storage::StorageKindTag<StorageKind::LeanVec8x8>{},
+                    std::forward<Args>(args)...
+                );
             default:
                 throw StatusException{
                     ErrorCode::INVALID_ARGUMENT, "SVS LeanVec storage kind required"};

--- a/bindings/cpp/src/flat_index_impl.h
+++ b/bindings/cpp/src/flat_index_impl.h
@@ -96,7 +96,7 @@ class FlatIndexImpl {
 
     static FlatIndexImpl* load(std::istream& in, MetricType metric) {
         auto threadpool = default_threadpool();
-        using storage_type = svs::runtime::storage::StorageType_t<storage::FP32Tag>;
+        using storage_type = svs::runtime::storage::StorageType_t<StorageKind::FP32>;
 
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
         return distance_dispatcher([&](auto&& distance) {
@@ -119,7 +119,7 @@ class FlatIndexImpl {
         auto threadpool = default_threadpool();
 
         auto storage = svs::runtime::storage::make_storage(
-            svs::runtime::storage::FP32Tag{}, data, threadpool
+            storage::StorageKindTag<StorageKind::FP32>{}, data, threadpool
         );
 
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric_type_));

--- a/bindings/cpp/src/flat_index_impl.h
+++ b/bindings/cpp/src/flat_index_impl.h
@@ -35,6 +35,8 @@ namespace runtime {
 
 // Vamana index implementation
 class FlatIndexImpl {
+    using allocator_type = svs::lib::Allocator<float>;
+
   public:
     FlatIndexImpl(size_t dim, MetricType metric)
         : dim_{dim}
@@ -96,7 +98,8 @@ class FlatIndexImpl {
 
     static FlatIndexImpl* load(std::istream& in, MetricType metric) {
         auto threadpool = default_threadpool();
-        using storage_type = svs::runtime::storage::StorageType_t<StorageKind::FP32>;
+        using storage_type = svs::runtime::storage::
+            StorageType_t<StorageKind::FP32, svs::lib::Allocator<float>>;
 
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
         return distance_dispatcher([&](auto&& distance) {
@@ -119,7 +122,7 @@ class FlatIndexImpl {
         auto threadpool = default_threadpool();
 
         auto storage = svs::runtime::storage::make_storage(
-            storage::StorageKindTag<StorageKind::FP32>{}, data, threadpool
+            storage::StorageType<StorageKind::FP32, allocator_type>{}, data, threadpool
         );
 
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric_type_));

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -81,118 +81,13 @@ inline bool is_supported_storage_kind(StorageKind kind) {
     return is_supported_non_leanvec_storage_kind(kind) || is_leanvec_storage_kind(kind);
 }
 
-///// IVF Data Types /////
-
-// Simple uncompressed data types
-template <typename T>
-using IVFSimpleDataType = svs::data::SimpleData<T, svs::Dynamic, svs::lib::Allocator<T>>;
-
-template <typename T>
-using IVFBlockedSimpleDataType =
-    svs::data::SimpleData<T, svs::Dynamic, svs::data::Blocked<svs::lib::Allocator<T>>>;
-
-// Scalar Quantization data types
-template <typename T>
-using IVFSQDataType =
-    svs::quantization::scalar::SQDataset<T, svs::Dynamic, svs::lib::Allocator<T>>;
-
-template <typename T>
-using IVFBlockedSQDataType = svs::quantization::scalar::
-    SQDataset<T, svs::Dynamic, svs::data::Blocked<svs::lib::Allocator<T>>>;
-
-#ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
-// LVQ data types
-template <size_t Primary, size_t Residual, typename Strategy>
-using IVFLVQDataType = svs::quantization::lvq::
-    LVQDataset<Primary, Residual, svs::Dynamic, Strategy, svs::lib::Allocator<std::byte>>;
-
-template <size_t Primary, size_t Residual, typename Strategy>
-using IVFBlockedLVQDataType = svs::quantization::lvq::LVQDataset<
-    Primary,
-    Residual,
-    svs::Dynamic,
-    Strategy,
-    svs::data::Blocked<svs::lib::Allocator<std::byte>>>;
-
-using Sequential = svs::quantization::lvq::Sequential;
-using Turbo16x8 = svs::quantization::lvq::Turbo<16, 8>;
-
-// LeanVec data types
-template <size_t I1, size_t I2>
-using IVFLeanVecDataType = svs::leanvec::LeanDataset<
-    svs::leanvec::UsingLVQ<I1>,
-    svs::leanvec::UsingLVQ<I2>,
-    svs::Dynamic,
-    svs::Dynamic,
-    svs::lib::Allocator<std::byte>>;
-
-template <size_t I1, size_t I2>
-using IVFBlockedLeanVecDataType = svs::leanvec::LeanDataset<
-    svs::leanvec::UsingLVQ<I1>,
-    svs::leanvec::UsingLVQ<I2>,
-    svs::Dynamic,
-    svs::Dynamic,
-    svs::data::Blocked<svs::lib::Allocator<std::byte>>>;
-#endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
-
-///// Storage Type Mapping /////
-
-// Map StorageKind to data type using storage tags
-template <storage::StorageTag Tag> struct IVFStorageType {
-    using type = storage::UnsupportedStorageType;
-};
-
-template <storage::StorageTag Tag> struct IVFBlockedStorageType {
-    using type = storage::UnsupportedStorageType;
-};
-
-template <storage::StorageTag Tag>
-using IVFStorageType_t = typename IVFStorageType<Tag>::type;
-
-template <storage::StorageTag Tag>
-using IVFBlockedStorageType_t = typename IVFBlockedStorageType<Tag>::type;
-
-// clang-format off
-template <> struct IVFStorageType<storage::FP32Tag> { using type = IVFSimpleDataType<float>; };
-template <> struct IVFStorageType<storage::FP16Tag> { using type = IVFSimpleDataType<svs::Float16>; };
-template <> struct IVFStorageType<storage::SQI8Tag> { using type = IVFSQDataType<std::int8_t>; };
-
-template <> struct IVFBlockedStorageType<storage::FP32Tag> { using type = IVFBlockedSimpleDataType<float>; };
-template <> struct IVFBlockedStorageType<storage::FP16Tag> { using type = IVFBlockedSimpleDataType<svs::Float16>; };
-template <> struct IVFBlockedStorageType<storage::SQI8Tag> { using type = IVFBlockedSQDataType<std::int8_t>; };
-// clang-format on
-
-#ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
-// clang-format off
-template <> struct IVFStorageType<storage::LVQ4x0Tag> { using type = IVFLVQDataType<4, 0, Turbo16x8>; };
-template <> struct IVFStorageType<storage::LVQ8x0Tag> { using type = IVFLVQDataType<8, 0, Sequential>; };
-template <> struct IVFStorageType<storage::LVQ4x4Tag> { using type = IVFLVQDataType<4, 4, Turbo16x8>; };
-template <> struct IVFStorageType<storage::LVQ4x8Tag> { using type = IVFLVQDataType<4, 8, Turbo16x8>; };
-
-template <> struct IVFBlockedStorageType<storage::LVQ4x0Tag> { using type = IVFBlockedLVQDataType<4, 0, Turbo16x8>; };
-template <> struct IVFBlockedStorageType<storage::LVQ8x0Tag> { using type = IVFBlockedLVQDataType<8, 0, Sequential>; };
-template <> struct IVFBlockedStorageType<storage::LVQ4x4Tag> { using type = IVFBlockedLVQDataType<4, 4, Turbo16x8>; };
-template <> struct IVFBlockedStorageType<storage::LVQ4x8Tag> { using type = IVFBlockedLVQDataType<4, 8, Turbo16x8>; };
-// clang-format on
-
-// clang-format off
-template <> struct IVFStorageType<storage::LeanVec4x4Tag> { using type = IVFLeanVecDataType<4, 4>; };
-template <> struct IVFStorageType<storage::LeanVec4x8Tag> { using type = IVFLeanVecDataType<4, 8>; };
-template <> struct IVFStorageType<storage::LeanVec8x8Tag> { using type = IVFLeanVecDataType<8, 8>; };
-
-template <> struct IVFBlockedStorageType<storage::LeanVec4x4Tag> { using type = IVFBlockedLeanVecDataType<4, 4>; };
-template <> struct IVFBlockedStorageType<storage::LeanVec4x8Tag> { using type = IVFBlockedLeanVecDataType<4, 8>; };
-template <> struct IVFBlockedStorageType<storage::LeanVec8x8Tag> { using type = IVFBlockedLeanVecDataType<8, 8>; };
-// clang-format on
-#endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
-
 ///// Storage Factory /////
 
 template <typename DataType> struct IVFStorageFactory;
 
 // Unsupported storage factory
 template <> struct IVFStorageFactory<storage::UnsupportedStorageType> {
-    using DataType = IVFSimpleDataType<float>;
+    using DataType = storage::SimpleDatasetType<float, svs::lib::Allocator<float>>;
 
     template <svs::threads::ThreadPool Pool>
     static DataType
@@ -276,52 +171,66 @@ struct IVFStorageFactory<svs::leanvec::LeanDataset<Primary, Secondary, E1, E2, A
 #endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 
 // Helper to make compressed data (non-LeanVec)
-template <typename Tag, svs::threads::ThreadPool Pool>
-    requires storage::StorageTag<std::decay_t<Tag>>
+template <StorageKind Kind, typename Alloc, svs::threads::ThreadPool Pool>
 auto make_ivf_storage(
-    Tag&&, const svs::data::ConstSimpleDataView<float>& data, Pool& pool, size_t arg = 0
+    storage::StorageType<Kind, Alloc> SVS_UNUSED(tag),
+    const svs::data::ConstSimpleDataView<float>& data,
+    Pool& pool,
+    size_t arg = 0
 ) {
-    using TagDecay = std::decay_t<Tag>;
-    return IVFStorageFactory<IVFStorageType_t<TagDecay>>::compress(data, pool, arg);
+    static_assert(
+        !svs::data::is_blocked_v<Alloc>, "Allocator must not be blocked for IVF storage"
+    );
+    return IVFStorageFactory<storage::StorageType_t<Kind, Alloc>>::compress(
+        data, pool, arg
+    );
 }
 
-template <typename Tag, svs::threads::ThreadPool Pool>
-    requires storage::StorageTag<std::decay_t<Tag>>
+template <StorageKind Kind, typename Alloc, svs::threads::ThreadPool Pool>
 auto make_ivf_blocked_storage(
-    Tag&&, const svs::data::ConstSimpleDataView<float>& data, Pool& pool, size_t arg = 0
+    storage::StorageType<Kind, Alloc> SVS_UNUSED(tag),
+    const svs::data::ConstSimpleDataView<float>& data,
+    Pool& pool,
+    size_t arg = 0
 ) {
-    using TagDecay = std::decay_t<Tag>;
-    return IVFStorageFactory<IVFBlockedStorageType_t<TagDecay>>::compress(data, pool, arg);
+    static_assert(
+        svs::data::is_blocked_v<Alloc>, "Allocator must be blocked for IVF storage"
+    );
+    return IVFStorageFactory<storage::StorageType_t<Kind, Alloc>>::compress(
+        data, pool, arg
+    );
 }
 
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // LeanVec-specific make functions with matrices parameter
-template <typename Tag, svs::threads::ThreadPool Pool>
-    requires storage::StorageTag<std::decay_t<Tag>>
+template <StorageKind Kind, typename Alloc, svs::threads::ThreadPool Pool>
 auto make_ivf_leanvec_storage(
-    Tag&&,
+    storage::StorageType<Kind, Alloc> SVS_UNUSED(tag),
     const svs::data::ConstSimpleDataView<float>& data,
     Pool& pool,
     size_t leanvec_d,
     std::optional<svs::leanvec::LeanVecMatrices<svs::Dynamic>> matrices
 ) {
-    using TagDecay = std::decay_t<Tag>;
-    return IVFStorageFactory<IVFStorageType_t<TagDecay>>::compress(
+    static_assert(
+        !svs::data::is_blocked_v<Alloc>, "Allocator must not be blocked for IVF storage"
+    );
+    return IVFStorageFactory<storage::StorageType_t<Kind, Alloc>>::compress(
         data, pool, leanvec_d, std::move(matrices)
     );
 }
 
-template <typename Tag, svs::threads::ThreadPool Pool>
-    requires storage::StorageTag<std::decay_t<Tag>>
+template <StorageKind Kind, typename Alloc, svs::threads::ThreadPool Pool>
 auto make_ivf_blocked_leanvec_storage(
-    Tag&&,
+    storage::StorageType<Kind, Alloc> SVS_UNUSED(tag),
     const svs::data::ConstSimpleDataView<float>& data,
     Pool& pool,
     size_t leanvec_d,
     std::optional<svs::leanvec::LeanVecMatrices<svs::Dynamic>> matrices
 ) {
-    using TagDecay = std::decay_t<Tag>;
-    return IVFStorageFactory<IVFBlockedStorageType_t<TagDecay>>::compress(
+    static_assert(
+        svs::data::is_blocked_v<Alloc>, "Allocator must be blocked for IVF storage"
+    );
+    return IVFStorageFactory<storage::StorageType_t<Kind, Alloc>>::compress(
         data, pool, leanvec_d, std::move(matrices)
     );
 }
@@ -330,24 +239,45 @@ auto make_ivf_blocked_leanvec_storage(
 ///// Dispatch Functions /////
 
 // Dispatch on storage kind for IVF operations (excludes LeanVec - handled separately)
-template <typename F, typename... Args>
+template <typename Alloc, typename F, typename... Args>
 auto dispatch_ivf_storage_kind(StorageKind kind, F&& f, Args&&... args) {
     switch (kind) {
         case StorageKind::FP32:
-            return f(storage::FP32Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::FP32, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::FP16:
-            return f(storage::FP16Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::FP16, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::SQI8:
-            return f(storage::SQI8Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::SQI8, Alloc>{},
+                std::forward<Args>(args)...
+            );
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
         case StorageKind::LVQ4x0:
-            return f(storage::LVQ4x0Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LVQ4x0, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::LVQ8x0:
-            return f(storage::LVQ8x0Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LVQ8x0, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::LVQ4x4:
-            return f(storage::LVQ4x4Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LVQ4x4, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::LVQ4x8:
-            return f(storage::LVQ4x8Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LVQ4x8, Alloc>{},
+                std::forward<Args>(args)...
+            );
 #endif
         default:
             throw StatusException{
@@ -358,15 +288,24 @@ auto dispatch_ivf_storage_kind(StorageKind kind, F&& f, Args&&... args) {
 
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // Dispatch on LeanVec storage kinds only
-template <typename F, typename... Args>
+template <typename Alloc, typename F, typename... Args>
 auto dispatch_ivf_leanvec_storage_kind(StorageKind kind, F&& f, Args&&... args) {
     switch (kind) {
         case StorageKind::LeanVec4x4:
-            return f(storage::LeanVec4x4Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LeanVec4x4, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::LeanVec4x8:
-            return f(storage::LeanVec4x8Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LeanVec4x8, Alloc>{},
+                std::forward<Args>(args)...
+            );
         case StorageKind::LeanVec8x8:
-            return f(storage::LeanVec8x8Tag{}, std::forward<Args>(args)...);
+            return f(
+                storage::StorageType<StorageKind::LeanVec8x8, Alloc>{},
+                std::forward<Args>(args)...
+            );
         default:
             throw StatusException{
                 ErrorCode::INVALID_ARGUMENT, "LeanVec storage kind required"};
@@ -378,6 +317,8 @@ auto dispatch_ivf_leanvec_storage_kind(StorageKind kind, F&& f, Args&&... args) 
 
 // Static IVF index implementation (non-LeanVec storage kinds)
 class IVFIndexImpl {
+    using allocator_type = svs::lib::Allocator<float>;
+
   public:
     IVFIndexImpl(
         size_t dim,
@@ -481,25 +422,32 @@ class IVFIndexImpl {
         }
 
         // Dispatch on storage kind to load with correct data type
-        return ivf_storage::dispatch_ivf_storage_kind(storage_kind, [&](auto tag) {
-            using Tag = decltype(tag);
-            using DataType = ivf_storage::IVFStorageType_t<Tag>;
+        return ivf_storage::dispatch_ivf_storage_kind<allocator_type>(
+            storage_kind,
+            [&](auto tag) {
+                using Tag = decltype(tag);
+                using DataType = typename Tag::type;
 
-            svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
-            return distance_dispatcher([&](auto&& distance) {
-                auto impl = std::make_unique<svs::IVF>(
-                    svs::IVF::assemble<float, svs::BFloat16, DataType>(
-                        in,
-                        std::forward<decltype(distance)>(distance),
+                svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
+                return distance_dispatcher([&](auto&& distance) {
+                    auto impl = std::make_unique<svs::IVF>(
+                        svs::IVF::assemble<float, svs::BFloat16, DataType>(
+                            in,
+                            std::forward<decltype(distance)>(distance),
+                            num_threads,
+                            intra_query_threads
+                        )
+                    );
+                    return new IVFIndexImpl(
+                        std::move(impl),
+                        metric,
+                        storage_kind,
                         num_threads,
                         intra_query_threads
-                    )
-                );
-                return new IVFIndexImpl(
-                    std::move(impl), metric, storage_kind, num_threads, intra_query_threads
-                );
-            });
-        });
+                    );
+                });
+            }
+        );
     }
 
   protected:
@@ -594,18 +542,22 @@ class IVFIndexImpl {
             );
 
             // Dispatch on storage kind to compress and assemble
-            return ivf_storage::dispatch_ivf_storage_kind(storage_kind_, [&](auto tag) {
-                // Compress data to target storage type using the factory
-                auto compressed_data = ivf_storage::make_ivf_storage(tag, data, threadpool);
+            return ivf_storage::dispatch_ivf_storage_kind<allocator_type>(
+                storage_kind_,
+                [&](auto tag) {
+                    // Compress data to target storage type using the factory
+                    auto compressed_data =
+                        ivf_storage::make_ivf_storage(tag, data, threadpool);
 
-                return new svs::IVF(svs::IVF::assemble_from_clustering<float>(
-                    std::move(clustering),
-                    std::move(compressed_data),
-                    std::forward<decltype(distance)>(distance),
-                    num_threads_,
-                    intra_query_threads_
-                ));
-            });
+                    return new svs::IVF(svs::IVF::assemble_from_clustering<float>(
+                        std::move(clustering),
+                        std::move(compressed_data),
+                        std::forward<decltype(distance)>(distance),
+                        num_threads_,
+                        intra_query_threads_
+                    ));
+                }
+            );
         }));
     }
 
@@ -623,6 +575,8 @@ class IVFIndexImpl {
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // Static IVF index implementation for LeanVec storage kinds
 class IVFIndexLeanVecImpl : public IVFIndexImpl {
+    using allocator_type = svs::lib::Allocator<std::byte>;
+
   public:
     using LeanVecMatricesType = LeanVecTrainingDataImpl::LeanVecMatricesType;
 
@@ -692,25 +646,32 @@ class IVFIndexLeanVecImpl : public IVFIndexImpl {
             num_threads = static_cast<size_t>(omp_get_max_threads());
         }
 
-        return ivf_storage::dispatch_ivf_leanvec_storage_kind(storage_kind, [&](auto tag) {
-            using Tag = decltype(tag);
-            using DataType = ivf_storage::IVFStorageType_t<Tag>;
+        return ivf_storage::dispatch_ivf_leanvec_storage_kind<allocator_type>(
+            storage_kind,
+            [&](auto tag) {
+                using Tag = decltype(tag);
+                using DataType = typename Tag::type;
 
-            svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
-            return distance_dispatcher([&](auto&& distance) {
-                auto impl = std::make_unique<svs::IVF>(
-                    svs::IVF::assemble<float, svs::BFloat16, DataType>(
-                        in,
-                        std::forward<decltype(distance)>(distance),
+                svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
+                return distance_dispatcher([&](auto&& distance) {
+                    auto impl = std::make_unique<svs::IVF>(
+                        svs::IVF::assemble<float, svs::BFloat16, DataType>(
+                            in,
+                            std::forward<decltype(distance)>(distance),
+                            num_threads,
+                            intra_query_threads
+                        )
+                    );
+                    return new IVFIndexLeanVecImpl(
+                        std::move(impl),
+                        metric,
+                        storage_kind,
                         num_threads,
                         intra_query_threads
-                    )
-                );
-                return new IVFIndexLeanVecImpl(
-                    std::move(impl), metric, storage_kind, num_threads, intra_query_threads
-                );
-            });
-        });
+                    );
+                });
+            }
+        );
     }
 
   protected:
@@ -745,7 +706,7 @@ class IVFIndexLeanVecImpl : public IVFIndexImpl {
             );
 
             // Dispatch on LeanVec storage kind to compress and assemble
-            return ivf_storage::dispatch_ivf_leanvec_storage_kind(
+            return ivf_storage::dispatch_ivf_leanvec_storage_kind<allocator_type>(
                 storage_kind_,
                 [&](auto tag) {
                     // Compress data to LeanVec storage type using the factory with matrices

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -86,8 +86,9 @@ inline bool is_supported_storage_kind(StorageKind kind) {
 template <typename DataType> struct IVFStorageFactory;
 
 // Unsupported storage factory
-template <> struct IVFStorageFactory<storage::UnsupportedStorageType> {
-    using DataType = storage::SimpleDatasetType<float, svs::lib::Allocator<float>>;
+template <typename Alloc> struct IVFStorageFactory<storage::UnsupportedStorageType<Alloc>> {
+    using DataType = storage::
+        SimpleDatasetType<float, storage::rebind_extracted_allocator_t<float, Alloc>>;
 
     template <svs::threads::ThreadPool Pool>
     static DataType

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -159,9 +159,12 @@ template <typename Alloc>
 Alloc make_allocator(svs::lib::PowerOfTwo blocksize_bytes)
     requires(svs::data::is_blocked_v<Alloc>)
 {
-    assert(
-        blocksize_bytes.raw() > 0 && "Blocked storage types require a non-zero blocksize"
-    );
+    if (blocksize_bytes.raw() == 0) {
+        throw StatusException(
+            ErrorCode::INVALID_ARGUMENT,
+            "Blocked storage types require a non-zero blocksize"
+        );
+    }
     auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
     return Alloc(parameters);
 }
@@ -419,7 +422,9 @@ auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
         SVS_DISPATCH_STORAGE_KIND(LeanVec4x8);
         SVS_DISPATCH_STORAGE_KIND(LeanVec8x8);
         default:
-            throw ANNEXCEPTION("not supported SVS storage kind");
+            throw StatusException(
+                ErrorCode::INVALID_ARGUMENT, "Unknown or unsupported SVS storage kind"
+            );
     }
 
 #undef SVS_DISPATCH_STORAGE_KIND

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -176,11 +176,13 @@ using SQDatasetType = svs::quantization::scalar::SQDataset<T, svs::Dynamic, Allo
 // Storage type mapping
 
 // Unsupported storage type defined as unique type to cause runtime error if used
-struct UnsupportedStorageType {};
+template <typename Alloc> struct UnsupportedStorageType {
+    using allocator_type = Alloc; // Dummy allocator type to satisfy template requirements
+};
 
 template <StorageKind Kind, typename Alloc> struct StorageType {
-    using type = UnsupportedStorageType;
     using allocator_type = Alloc;
+    using type = UnsupportedStorageType<Alloc>;
 };
 template <StorageKind Kind, typename Alloc>
 using StorageType_t = typename StorageType<Kind, Alloc>::type;
@@ -203,8 +205,9 @@ template <typename T> struct StorageFactory;
 
 // Unsupported storage type factory returning runtime error when attempted to be used.
 // Return type defined to simple to allow substitution in templates.
-template <> struct StorageFactory<UnsupportedStorageType> {
-    using StorageType = SimpleDatasetType<float, svs::lib::Allocator<float>>;
+template <typename Alloc> struct StorageFactory<UnsupportedStorageType<Alloc>> {
+    using StorageType =
+        SimpleDatasetType<float, rebind_extracted_allocator_t<float, Alloc>>;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -148,21 +148,22 @@ struct ExtractedAllocatorRebinder<T, svs::data::Blocked<Alloc>> {
 template <typename T, typename Alloc>
 using rebind_extracted_allocator_t = typename ExtractedAllocatorRebinder<T, Alloc>::type;
 
-template <typename Alloc> Alloc make_allocator(svs::lib::PowerOfTwo blocksize_bytes) {
-    if constexpr (svs::data::is_blocked_v<Alloc>) {
-        assert(
-            blocksize_bytes.raw() > 0 &&
-            "Blocked storage types require a non-zero blocksize"
-        );
-        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
-        return Alloc(parameters);
-    } else {
-        assert(
-            blocksize_bytes.raw() == 0 &&
-            "Non-blocked storage types should have blocksize_bytes set to 0"
-        );
-        return Alloc();
-    }
+template <typename Alloc>
+Alloc make_allocator()
+    requires(!svs::data::is_blocked_v<Alloc>)
+{
+    return Alloc{};
+}
+
+template <typename Alloc>
+Alloc make_allocator(svs::lib::PowerOfTwo blocksize_bytes)
+    requires(svs::data::is_blocked_v<Alloc>)
+{
+    assert(
+        blocksize_bytes.raw() > 0 && "Blocked storage types require a non-zero blocksize"
+    );
+    auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
+    return Alloc(parameters);
 }
 
 // Storage types

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -123,28 +123,79 @@ inline bool is_supported_storage_kind(StorageKind kind) {
     return true;
 }
 
-// Storage types
-template <typename T>
-using SimpleDatasetType =
-    svs::data::SimpleData<T, svs::Dynamic, svs::data::Blocked<svs::lib::Allocator<T>>>;
+template <typename A> struct AllocatorTypeExtractor {
+    using type = A;
+};
 
-template <typename T>
-using SQDatasetType = svs::quantization::scalar::
-    SQDataset<T, svs::Dynamic, svs::data::Blocked<svs::lib::Allocator<T>>>;
+template <typename A>
+concept AllocatorAwareType = requires { typename A::allocator_type; };
+
+template <AllocatorAwareType A> struct AllocatorTypeExtractor<A> {
+    using type = typename A::allocator_type;
+};
+
+template <typename A> using extract_allocator_t = typename AllocatorTypeExtractor<A>::type;
+
+template <typename T, typename Alloc> struct ExtractedAllocatorRebinder {
+    using type = lib::rebind_allocator_t<T, extract_allocator_t<Alloc>>;
+};
+
+template <typename T, typename Alloc>
+struct ExtractedAllocatorRebinder<T, svs::data::Blocked<Alloc>> {
+    using type = svs::data::Blocked<lib::rebind_allocator_t<T, extract_allocator_t<Alloc>>>;
+};
+
+template <typename T, typename Alloc>
+using rebind_extracted_allocator_t = typename ExtractedAllocatorRebinder<T, Alloc>::type;
+
+template <typename Alloc> Alloc make_allocator(svs::lib::PowerOfTwo blocksize_bytes) {
+    if constexpr (svs::data::is_blocked_v<Alloc>) {
+        assert(
+            blocksize_bytes.raw() > 0 &&
+            "Blocked storage types require a non-zero blocksize"
+        );
+        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
+        return Alloc(parameters);
+    } else {
+        assert(
+            blocksize_bytes.raw() == 0 &&
+            "Non-blocked storage types should have blocksize_bytes set to 0"
+        );
+        return Alloc();
+    }
+}
+
+// Storage types
+template <typename T, typename Alloc>
+using SimpleDatasetType = svs::data::SimpleData<T, svs::Dynamic, Alloc>;
+
+template <typename T, typename Alloc>
+using SQDatasetType = svs::quantization::scalar::SQDataset<T, svs::Dynamic, Alloc>;
 
 // Storage type mapping
 
 // Unsupported storage type defined as unique type to cause runtime error if used
 struct UnsupportedStorageType {};
 
-// clang-format off
-template <StorageKind Kind> struct StorageType { using type = UnsupportedStorageType; };
-template <StorageKind Kind> using StorageType_t = typename StorageType<Kind>::type;
+template <StorageKind Kind, typename Alloc> struct StorageType {
+    using type = UnsupportedStorageType;
+    using allocator_type = Alloc;
+};
+template <StorageKind Kind, typename Alloc>
+using StorageType_t = typename StorageType<Kind, Alloc>::type;
 
-template <> struct StorageType<StorageKind::FP32> { using type = SimpleDatasetType<float>; };
-template <> struct StorageType<StorageKind::FP16> { using type = SimpleDatasetType<svs::Float16>; };
-template <> struct StorageType<StorageKind::SQI8> { using type = SQDatasetType<std::int8_t>; };
-// clang-format on
+template <typename Alloc> struct StorageType<StorageKind::FP32, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<float, Alloc>;
+    using type = SimpleDatasetType<float, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::FP16, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<svs::Float16, Alloc>;
+    using type = SimpleDatasetType<svs::Float16, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::SQI8, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::int8_t, Alloc>;
+    using type = SQDatasetType<std::int8_t, allocator_type>;
+};
 
 // Storage factory
 template <typename T> struct StorageFactory;
@@ -152,13 +203,13 @@ template <typename T> struct StorageFactory;
 // Unsupported storage type factory returning runtime error when attempted to be used.
 // Return type defined to simple to allow substitution in templates.
 template <> struct StorageFactory<UnsupportedStorageType> {
-    using StorageType = SimpleDatasetType<float>;
+    using StorageType = SimpleDatasetType<float, svs::lib::Allocator<float>>;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(
         const svs::data::ConstSimpleDataView<float>& SVS_UNUSED(data),
         Pool& SVS_UNUSED(pool),
-        svs::lib::PowerOfTwo SVS_UNUSED(blocksize_bytes)
+        const typename StorageType::allocator_type& SVS_UNUSED(alloc) = {}
     ) {
         throw StatusException(
             ErrorCode::NOT_IMPLEMENTED, "Requested storage kind is not supported"
@@ -174,18 +225,16 @@ template <> struct StorageFactory<UnsupportedStorageType> {
     }
 };
 
-template <typename ElementType> struct StorageFactory<SimpleDatasetType<ElementType>> {
-    using StorageType = SimpleDatasetType<ElementType>;
+template <typename T, size_t Extent, typename Alloc>
+struct StorageFactory<svs::data::SimpleData<T, Extent, Alloc>> {
+    using StorageType = svs::data::SimpleData<T, Extent, Alloc>;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(
         const svs::data::ConstSimpleDataView<float>& data,
         Pool& pool,
-        svs::lib::PowerOfTwo blocksize_bytes =
-            svs::data::BlockingParameters::default_blocksize_bytes
+        const Alloc& alloc = {}
     ) {
-        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
-        typename StorageType::allocator_type alloc(parameters);
         StorageType result(data.size(), data.dimensions(), alloc);
         svs::threads::parallel_for(
             pool,
@@ -206,19 +255,17 @@ template <typename ElementType> struct StorageFactory<SimpleDatasetType<ElementT
 };
 
 // SQ Storage support
-template <svs::quantization::scalar::IsSQData SQStorageType>
-struct StorageFactory<SQStorageType> {
-    using StorageType = SQStorageType;
+template <typename T, size_t Extent, typename Alloc>
+struct StorageFactory<svs::quantization::scalar::SQDataset<T, Extent, Alloc>> {
+    using StorageType = svs::quantization::scalar::SQDataset<T, Extent, Alloc>;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(
         const svs::data::ConstSimpleDataView<float>& data,
         Pool& pool,
-        svs::lib::PowerOfTwo blocksize_bytes
+        const Alloc& alloc = {}
     ) {
-        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
-        typename StorageType::allocator_type alloc(parameters);
-        return SQStorageType::compress(data, pool, alloc);
+        return StorageType::compress(data, pool, alloc);
     }
 
     template <typename... Args>
@@ -229,37 +276,49 @@ struct StorageFactory<SQStorageType> {
 
 // LVQ Storage support
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
-template <size_t Primary, size_t Residual, typename Strategy>
-using LVQDatasetType = svs::quantization::lvq::LVQDataset<
-    Primary,
-    Residual,
-    svs::Dynamic,
-    Strategy,
-    svs::data::Blocked<svs::lib::Allocator<std::byte>>>;
-
 using Sequential = svs::quantization::lvq::Sequential;
 using Turbo16x8 = svs::quantization::lvq::Turbo<16, 8>;
+template <size_t Primary, size_t Residual>
+using AutoStrategy = std::conditional_t<(Primary == 4), Turbo16x8, Sequential>;
 
-// clang-format off
-template <> struct StorageType<StorageKind::LVQ4x0> { using type = LVQDatasetType<4, 0, Turbo16x8>; };
-template <> struct StorageType<StorageKind::LVQ8x0> { using type = LVQDatasetType<8, 0, Sequential>; };
-template <> struct StorageType<StorageKind::LVQ4x4> { using type = LVQDatasetType<4, 4, Turbo16x8>; };
-template <> struct StorageType<StorageKind::LVQ4x8> { using type = LVQDatasetType<4, 8, Turbo16x8>; };
-// clang-format on
+template <
+    size_t Primary,
+    size_t Residual,
+    typename Alloc,
+    size_t Extent = svs::Dynamic,
+    svs::quantization::lvq::LVQPackingStrategy Strategy = AutoStrategy<Primary, Residual>>
+using LVQDatasetType =
+    svs::quantization::lvq::LVQDataset<Primary, Residual, Extent, Strategy, Alloc>;
+
+template <typename Alloc> struct StorageType<StorageKind::LVQ4x0, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LVQDatasetType<4, 0, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LVQ8x0, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LVQDatasetType<8, 0, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LVQ4x4, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LVQDatasetType<4, 4, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LVQ4x8, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LVQDatasetType<4, 8, allocator_type>;
+};
 
 template <svs::quantization::lvq::IsLVQDataset LVQStorageType>
 struct StorageFactory<LVQStorageType> {
     using StorageType = LVQStorageType;
+    using Alloc = typename StorageType::allocator_type;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(
         const svs::data::ConstSimpleDataView<float>& data,
         Pool& pool,
-        svs::lib::PowerOfTwo blocksize_bytes
+        const Alloc& alloc = {}
     ) {
-        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
-        typename LVQStorageType::allocator_type alloc(parameters);
-        return LVQStorageType::compress(data, pool, 0, alloc);
+        return StorageType::compress(data, pool, 0, alloc);
     }
 
     template <typename... Args>
@@ -269,37 +328,48 @@ struct StorageFactory<LVQStorageType> {
 };
 
 // LeanVec Storage support
-template <size_t I1, size_t I2>
+template <
+    size_t I1,
+    size_t I2,
+    typename Alloc,
+    size_t LeanVecDims = svs::Dynamic,
+    size_t Extent = svs::Dynamic>
 using LeanDatasetType = svs::leanvec::LeanDataset<
     svs::leanvec::UsingLVQ<I1>,
     svs::leanvec::UsingLVQ<I2>,
-    svs::Dynamic,
-    svs::Dynamic,
-    svs::data::Blocked<svs::lib::Allocator<std::byte>>>;
+    LeanVecDims,
+    Extent,
+    Alloc>;
 
-// clang-format off
-template <> struct StorageType<StorageKind::LeanVec4x4> { using type = LeanDatasetType<4, 4>; };
-template <> struct StorageType<StorageKind::LeanVec4x8> { using type = LeanDatasetType<4, 8>; };
-template <> struct StorageType<StorageKind::LeanVec8x8> { using type = LeanDatasetType<8, 8>; };
-// clang-format on
+template <typename Alloc> struct StorageType<StorageKind::LeanVec4x4, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LeanDatasetType<4, 4, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LeanVec4x8, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LeanDatasetType<4, 8, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LeanVec8x8, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LeanDatasetType<8, 8, allocator_type>;
+};
 
 template <svs::leanvec::IsLeanDataset LeanVecStorageType>
 struct StorageFactory<LeanVecStorageType> {
     using StorageType = LeanVecStorageType;
+    using Alloc = typename StorageType::allocator_type;
 
     template <svs::threads::ThreadPool Pool>
     static StorageType init(
         const svs::data::ConstSimpleDataView<float>& data,
         Pool& pool,
-        svs::lib::PowerOfTwo blocksize_bytes,
+        const Alloc& alloc = {},
         size_t leanvec_d = 0,
         std::optional<svs::leanvec::LeanVecMatrices<svs::Dynamic>> matrices = std::nullopt
     ) {
         if (leanvec_d == 0) {
             leanvec_d = (data.dimensions() + 1) / 2;
         }
-        auto parameters = svs::data::BlockingParameters{.blocksize_bytes = blocksize_bytes};
-        typename LeanVecStorageType::allocator_type alloc(parameters);
         return LeanVecStorageType::reduce(
             data, std::move(matrices), pool, 0, svs::lib::MaybeStatic{leanvec_d}, alloc
         );
@@ -312,21 +382,17 @@ struct StorageFactory<LeanVecStorageType> {
 };
 #endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 
-template <StorageKind K> struct StorageKindTag {
-    static constexpr StorageKind value = K;
-};
-
-template <StorageKind Kind, typename... Args>
-auto make_storage(StorageKindTag<Kind> SVS_UNUSED(tag), Args&&... args) {
-    return StorageFactory<StorageType_t<Kind>>::init(std::forward<Args>(args)...);
+template <StorageKind Kind, typename Alloc, typename... Args>
+auto make_storage(StorageType<Kind, Alloc> SVS_UNUSED(tag), Args&&... args) {
+    return StorageFactory<StorageType_t<Kind, Alloc>>::init(std::forward<Args>(args)...);
 }
 
-template <StorageKind Kind, typename... Args>
-auto load_storage(StorageKindTag<Kind> SVS_UNUSED(tag), Args&&... args) {
-    return StorageFactory<StorageType_t<Kind>>::load(std::forward<Args>(args)...);
+template <StorageKind Kind, typename Alloc, typename... Args>
+auto load_storage(StorageType<Kind, Alloc> SVS_UNUSED(tag), Args&&... args) {
+    return StorageFactory<StorageType_t<Kind, Alloc>>::load(std::forward<Args>(args)...);
 }
 
-template <typename F, typename... Args>
+template <typename Alloc, typename F, typename... Args>
 auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
     if (!is_supported_storage_kind(kind)) {
         throw StatusException(
@@ -335,7 +401,8 @@ auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
     }
 #define SVS_DISPATCH_STORAGE_KIND(Kind) \
     case StorageKind::Kind:             \
-        return f(StorageKindTag<StorageKind::Kind>{}, std::forward<Args>(args)...);
+        return f(StorageType<StorageKind::Kind, Alloc>{}, std::forward<Args>(args)...)
+
     switch (kind) {
         SVS_DISPATCH_STORAGE_KIND(FP32);
         SVS_DISPATCH_STORAGE_KIND(FP16);
@@ -350,6 +417,7 @@ auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
         default:
             throw ANNEXCEPTION("not supported SVS storage kind");
     }
+
 #undef SVS_DISPATCH_STORAGE_KIND
 }
 } // namespace storage

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -123,35 +123,6 @@ inline bool is_supported_storage_kind(StorageKind kind) {
     return true;
 }
 
-// Storage kind processing
-// Most kinds map to std::byte storage, but some have specific element types.
-// Storage kind tag types for function argument deduction
-template <StorageKind K> struct StorageKindTag {
-    static constexpr StorageKind value = K;
-};
-
-#define SVS_DEFINE_STORAGE_KIND_TAG(Kind) \
-    using Kind##Tag = StorageKindTag<StorageKind::Kind>
-
-SVS_DEFINE_STORAGE_KIND_TAG(FP32);
-SVS_DEFINE_STORAGE_KIND_TAG(FP16);
-SVS_DEFINE_STORAGE_KIND_TAG(SQI8);
-SVS_DEFINE_STORAGE_KIND_TAG(LVQ4x0);
-SVS_DEFINE_STORAGE_KIND_TAG(LVQ8x0);
-SVS_DEFINE_STORAGE_KIND_TAG(LVQ4x4);
-SVS_DEFINE_STORAGE_KIND_TAG(LVQ4x8);
-SVS_DEFINE_STORAGE_KIND_TAG(LeanVec4x4);
-SVS_DEFINE_STORAGE_KIND_TAG(LeanVec4x8);
-SVS_DEFINE_STORAGE_KIND_TAG(LeanVec8x8);
-
-#undef SVS_DEFINE_STORAGE_KIND_TAG
-
-template <typename T> inline constexpr bool is_storage_tag = false;
-template <StorageKind K> inline constexpr bool is_storage_tag<StorageKindTag<K>> = true;
-
-template <typename T>
-concept StorageTag = is_storage_tag<T>;
-
 // Storage types
 template <typename T>
 using SimpleDatasetType =
@@ -167,12 +138,12 @@ using SQDatasetType = svs::quantization::scalar::
 struct UnsupportedStorageType {};
 
 // clang-format off
-template <StorageTag Tag> struct StorageType { using type = UnsupportedStorageType; };
-template <StorageTag Tag> using StorageType_t = typename StorageType<Tag>::type;
+template <StorageKind Kind> struct StorageType { using type = UnsupportedStorageType; };
+template <StorageKind Kind> using StorageType_t = typename StorageType<Kind>::type;
 
-template <> struct StorageType<FP32Tag> { using type = SimpleDatasetType<float>; };
-template <> struct StorageType<FP16Tag> { using type = SimpleDatasetType<svs::Float16>; };
-template <> struct StorageType<SQI8Tag> { using type = SQDatasetType<std::int8_t>; };
+template <> struct StorageType<StorageKind::FP32> { using type = SimpleDatasetType<float>; };
+template <> struct StorageType<StorageKind::FP16> { using type = SimpleDatasetType<svs::Float16>; };
+template <> struct StorageType<StorageKind::SQI8> { using type = SQDatasetType<std::int8_t>; };
 // clang-format on
 
 // Storage factory
@@ -270,10 +241,10 @@ using Sequential = svs::quantization::lvq::Sequential;
 using Turbo16x8 = svs::quantization::lvq::Turbo<16, 8>;
 
 // clang-format off
-template <> struct StorageType<LVQ4x0Tag> { using type = LVQDatasetType<4, 0, Turbo16x8>; };
-template <> struct StorageType<LVQ8x0Tag> { using type = LVQDatasetType<8, 0, Sequential>; };
-template <> struct StorageType<LVQ4x4Tag> { using type = LVQDatasetType<4, 4, Turbo16x8>; };
-template <> struct StorageType<LVQ4x8Tag> { using type = LVQDatasetType<4, 8, Turbo16x8>; };
+template <> struct StorageType<StorageKind::LVQ4x0> { using type = LVQDatasetType<4, 0, Turbo16x8>; };
+template <> struct StorageType<StorageKind::LVQ8x0> { using type = LVQDatasetType<8, 0, Sequential>; };
+template <> struct StorageType<StorageKind::LVQ4x4> { using type = LVQDatasetType<4, 4, Turbo16x8>; };
+template <> struct StorageType<StorageKind::LVQ4x8> { using type = LVQDatasetType<4, 8, Turbo16x8>; };
 // clang-format on
 
 template <svs::quantization::lvq::IsLVQDataset LVQStorageType>
@@ -307,9 +278,9 @@ using LeanDatasetType = svs::leanvec::LeanDataset<
     svs::data::Blocked<svs::lib::Allocator<std::byte>>>;
 
 // clang-format off
-template <> struct StorageType<LeanVec4x4Tag> { using type = LeanDatasetType<4, 4>; };
-template <> struct StorageType<LeanVec4x8Tag> { using type = LeanDatasetType<4, 8>; };
-template <> struct StorageType<LeanVec8x8Tag> { using type = LeanDatasetType<8, 8>; };
+template <> struct StorageType<StorageKind::LeanVec4x4> { using type = LeanDatasetType<4, 4>; };
+template <> struct StorageType<StorageKind::LeanVec4x8> { using type = LeanDatasetType<4, 8>; };
+template <> struct StorageType<StorageKind::LeanVec8x8> { using type = LeanDatasetType<8, 8>; };
 // clang-format on
 
 template <svs::leanvec::IsLeanDataset LeanVecStorageType>
@@ -341,14 +312,18 @@ struct StorageFactory<LeanVecStorageType> {
 };
 #endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 
-template <StorageTag Tag, typename... Args>
-auto make_storage(Tag&& SVS_UNUSED(tag), Args&&... args) {
-    return StorageFactory<StorageType_t<Tag>>::init(std::forward<Args>(args)...);
+template <StorageKind K> struct StorageKindTag {
+    static constexpr StorageKind value = K;
+};
+
+template <StorageKind Kind, typename... Args>
+auto make_storage(StorageKindTag<Kind> SVS_UNUSED(tag), Args&&... args) {
+    return StorageFactory<StorageType_t<Kind>>::init(std::forward<Args>(args)...);
 }
 
-template <StorageTag Tag, typename... Args>
-auto load_storage(Tag&& SVS_UNUSED(tag), Args&&... args) {
-    return StorageFactory<StorageType_t<Tag>>::load(std::forward<Args>(args)...);
+template <StorageKind Kind, typename... Args>
+auto load_storage(StorageKindTag<Kind> SVS_UNUSED(tag), Args&&... args) {
+    return StorageFactory<StorageType_t<Kind>>::load(std::forward<Args>(args)...);
 }
 
 template <typename F, typename... Args>
@@ -358,30 +333,24 @@ auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
             ErrorCode::NOT_IMPLEMENTED, "Requested storage kind is not supported by CPU"
         );
     }
+#define SVS_DISPATCH_STORAGE_KIND(Kind) \
+    case StorageKind::Kind:             \
+        return f(StorageKindTag<StorageKind::Kind>{}, std::forward<Args>(args)...);
     switch (kind) {
-        case StorageKind::FP32:
-            return f(FP32Tag{}, std::forward<Args>(args)...);
-        case StorageKind::FP16:
-            return f(FP16Tag{}, std::forward<Args>(args)...);
-        case StorageKind::SQI8:
-            return f(SQI8Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LVQ4x0:
-            return f(LVQ4x0Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LVQ8x0:
-            return f(LVQ8x0Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LVQ4x4:
-            return f(LVQ4x4Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LVQ4x8:
-            return f(LVQ4x8Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LeanVec4x4:
-            return f(LeanVec4x4Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LeanVec4x8:
-            return f(LeanVec4x8Tag{}, std::forward<Args>(args)...);
-        case StorageKind::LeanVec8x8:
-            return f(LeanVec8x8Tag{}, std::forward<Args>(args)...);
+        SVS_DISPATCH_STORAGE_KIND(FP32);
+        SVS_DISPATCH_STORAGE_KIND(FP16);
+        SVS_DISPATCH_STORAGE_KIND(SQI8);
+        SVS_DISPATCH_STORAGE_KIND(LVQ4x0);
+        SVS_DISPATCH_STORAGE_KIND(LVQ8x0);
+        SVS_DISPATCH_STORAGE_KIND(LVQ4x4);
+        SVS_DISPATCH_STORAGE_KIND(LVQ4x8);
+        SVS_DISPATCH_STORAGE_KIND(LeanVec4x4);
+        SVS_DISPATCH_STORAGE_KIND(LeanVec4x8);
+        SVS_DISPATCH_STORAGE_KIND(LeanVec8x8);
         default:
             throw ANNEXCEPTION("not supported SVS storage kind");
     }
+#undef SVS_DISPATCH_STORAGE_KIND
 }
 } // namespace storage
 

--- a/bindings/cpp/src/training_impl.h
+++ b/bindings/cpp/src/training_impl.h
@@ -41,21 +41,26 @@ struct LeanVecTrainingDataImpl {
 
     LeanVecTrainingDataImpl(LeanVecMatricesType&& matrices)
         : leanvec_dims_{matrices.view_data_matrix().dimensions()}
-        , leanvec_matrices_{std::move(matrices)} {}
+        , leanvec_matrices_{std::move(matrices)} {
+        if (!svs::detail::lvq_leanvec_enabled()) {
+            throw StatusException(
+                ErrorCode::NOT_IMPLEMENTED, "LeanVec is not supported by CPU."
+            );
+        }
+    }
 
     LeanVecTrainingDataImpl(
         const svs::data::ConstSimpleDataView<float>& data, size_t leanvec_dims
     )
-        : leanvec_dims_{leanvec_dims}
-        , leanvec_matrices_{compute_leanvec_matrices(data, leanvec_dims)} {}
+        : LeanVecTrainingDataImpl(compute_leanvec_matrices(data, leanvec_dims)) {}
 
     LeanVecTrainingDataImpl(
         const svs::data::ConstSimpleDataView<float>& data,
         const svs::data::ConstSimpleDataView<float>& queries,
         size_t leanvec_dims
     )
-        : leanvec_dims_{leanvec_dims}
-        , leanvec_matrices_{compute_leanvec_matrices_ood(data, queries, leanvec_dims)} {}
+        : LeanVecTrainingDataImpl(compute_leanvec_matrices_ood(data, queries, leanvec_dims)
+          ) {}
 
     size_t get_leanvec_dims() const { return leanvec_dims_; }
     const LeanVecMatricesType& get_leanvec_matrices() const { return leanvec_matrices_; }

--- a/bindings/cpp/src/vamana_index.cpp
+++ b/bindings/cpp/src/vamana_index.cpp
@@ -199,7 +199,7 @@ Status VamanaIndexLeanVec::
     build(VamanaIndex**, size_t, MetricType, StorageKind, size_t, const VamanaIndex::BuildParams&, const VamanaIndex::SearchParams&) noexcept {
     return Status(
         ErrorCode::NOT_IMPLEMENTED,
-        "DynamicVamanaIndexLeanVec is not supported in this build configuration."
+        "VamanaIndexLeanVec is not supported in this build configuration."
     );
 }
 
@@ -207,7 +207,7 @@ Status VamanaIndexLeanVec::
     build(VamanaIndex**, size_t, MetricType, StorageKind, const LeanVecTrainingData*, const VamanaIndex::BuildParams&, const VamanaIndex::SearchParams&) noexcept {
     return Status(
         ErrorCode::NOT_IMPLEMENTED,
-        "DynamicVamanaIndexLeanVec is not supported in this build configuration."
+        "VamanaIndexLeanVec is not supported in this build configuration."
     );
 }
 #endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC

--- a/bindings/cpp/src/vamana_index.cpp
+++ b/bindings/cpp/src/vamana_index.cpp
@@ -16,11 +16,196 @@
 
 #include "svs/runtime/vamana_index.h"
 
+#include "svs_runtime_utils.h"
+#include "vamana_index_impl.h"
+
 namespace svs {
 namespace runtime {
+
+namespace {
+template <typename Impl = VamanaIndexImpl>
+struct VamanaIndexManagerBase : public VamanaIndex {
+    std::unique_ptr<Impl> impl_;
+
+    VamanaIndexManagerBase(std::unique_ptr<Impl> impl)
+        : impl_{std::move(impl)} {
+        assert(impl_ != nullptr);
+    }
+
+    VamanaIndexManagerBase(const VamanaIndexManagerBase&) = delete;
+    VamanaIndexManagerBase& operator=(const VamanaIndexManagerBase&) = delete;
+    VamanaIndexManagerBase(VamanaIndexManagerBase&&) = default;
+    VamanaIndexManagerBase& operator=(VamanaIndexManagerBase&&) = default;
+    ~VamanaIndexManagerBase() override = default;
+
+    Status add(size_t n, const float* x) noexcept override {
+        return runtime_error_wrapper([&] {
+            svs::data::ConstSimpleDataView<float> data{x, n, impl_->dimensions()};
+            impl_->add(data);
+            return Status_Ok;
+        });
+    }
+
+    Status reset() noexcept override {
+        return runtime_error_wrapper([&] {
+            impl_->reset();
+            return Status_Ok;
+        });
+    }
+
+    Status search(
+        size_t n,
+        const float* x,
+        size_t k,
+        float* distances,
+        size_t* labels,
+        const SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
+    ) const noexcept override {
+        return runtime_error_wrapper([&] {
+            auto result = svs::QueryResultView<size_t>{
+                svs::MatrixView<size_t>{svs::make_dims(n, k), labels},
+                svs::MatrixView<float>{svs::make_dims(n, k), distances}};
+            auto queries = svs::data::ConstSimpleDataView<float>(x, n, impl_->dimensions());
+            impl_->search(result, queries, params, filter);
+        });
+    }
+
+    Status range_search(
+        size_t n,
+        const float* x,
+        float radius,
+        const ResultsAllocator& results,
+        const SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
+    ) const noexcept override {
+        return runtime_error_wrapper([&] {
+            auto queries = svs::data::ConstSimpleDataView<float>(x, n, impl_->dimensions());
+            impl_->range_search(queries, radius, results, params, filter);
+        });
+    }
+
+    Status save(std::ostream& out) const noexcept override {
+        return runtime_error_wrapper([&] { impl_->save(out); });
+    }
+};
+} // namespace
 
 // VamanaIndex interface implementation
 VamanaIndex::~VamanaIndex() = default;
 
+Status VamanaIndex::check_storage_kind(StorageKind storage_kind) noexcept {
+    bool supported = false;
+    auto status = runtime_error_wrapper([&] {
+        supported = storage::is_supported_storage_kind(storage_kind);
+    });
+    if (!status.ok()) {
+        return status;
+    }
+    return supported ? Status_Ok
+                     : Status(
+                           ErrorCode::INVALID_ARGUMENT,
+                           "The specified storage kind is not compatible with the "
+                           "DynamicVamanaIndex"
+                       );
+}
+
+Status VamanaIndex::build(
+    VamanaIndex** index,
+    size_t dim,
+    MetricType metric,
+    StorageKind storage_kind,
+    const VamanaIndex::BuildParams& params,
+    const VamanaIndex::SearchParams& default_search_params
+) noexcept {
+    using Impl = VamanaIndexImpl;
+    *index = nullptr;
+
+    return runtime_error_wrapper([&] {
+        auto impl = std::make_unique<Impl>(
+            dim, metric, storage_kind, params, default_search_params
+        );
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
+Status VamanaIndex::destroy(VamanaIndex* index) noexcept {
+    return runtime_error_wrapper([&] { delete index; });
+}
+
+Status VamanaIndex::load(
+    VamanaIndex** index, std::istream& in, MetricType metric, StorageKind storage_kind
+) noexcept {
+    using Impl = VamanaIndexImpl;
+    *index = nullptr;
+    return runtime_error_wrapper([&] {
+        std::unique_ptr<Impl> impl{Impl::load(in, metric, storage_kind)};
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
+#ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
+// Specialization to build LeanVec-based Vamana index with specified leanvec dims
+Status VamanaIndexLeanVec::build(
+    VamanaIndex** index,
+    size_t dim,
+    MetricType metric,
+    StorageKind storage_kind,
+    size_t leanvec_dims,
+    const VamanaIndex::BuildParams& params,
+    const VamanaIndex::SearchParams& default_search_params
+) noexcept {
+    using Impl = VamanaIndexLeanVecImpl;
+    *index = nullptr;
+
+    return runtime_error_wrapper([&] {
+        auto impl = std::make_unique<Impl>(
+            dim, metric, storage_kind, leanvec_dims, params, default_search_params
+        );
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
+// Specialization to build LeanVec-based Vamana index with provided training data
+Status VamanaIndexLeanVec::build(
+    VamanaIndex** index,
+    size_t dim,
+    MetricType metric,
+    StorageKind storage_kind,
+    const LeanVecTrainingData* training_data,
+    const VamanaIndex::BuildParams& params,
+    const VamanaIndex::SearchParams& default_search_params
+) noexcept {
+    using Impl = VamanaIndexLeanVecImpl;
+    *index = nullptr;
+
+    return runtime_error_wrapper([&] {
+        auto training_data_impl =
+            static_cast<const LeanVecTrainingDataManager*>(training_data)->impl_;
+        auto impl = std::make_unique<Impl>(
+            dim, metric, storage_kind, training_data_impl, params, default_search_params
+        );
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
+#else  // SVS_RUNTIME_HAVE_LVQ_LEANVEC
+// LeanVec storage kind is not supported in this build configuration
+Status VamanaIndexLeanVec::
+    build(DynamicVamanaIndex**, size_t, MetricType, StorageKind, size_t, const DynamicVamanaIndex::BuildParams&, const DynamicVamanaIndex::SearchParams&, const DynamicVamanaIndex::DynamicIndexParams&) noexcept {
+    return Status(
+        ErrorCode::NOT_IMPLEMENTED,
+        "DynamicVamanaIndexLeanVec is not supported in this build configuration."
+    );
+}
+
+Status VamanaIndexLeanVec::
+    build(DynamicVamanaIndex**, size_t, MetricType, StorageKind, size_t, const DynamicVamanaIndex::BuildParams&, const DynamicVamanaIndex::SearchParams&, const DynamicVamanaIndex::DynamicIndexParams&) noexcept {
+    return Status(
+        ErrorCode::NOT_IMPLEMENTED,
+        "DynamicVamanaIndexLeanVec is not supported in this build configuration."
+    );
+}
+#endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 } // namespace runtime
 } // namespace svs

--- a/bindings/cpp/src/vamana_index.cpp
+++ b/bindings/cpp/src/vamana_index.cpp
@@ -102,12 +102,12 @@ Status VamanaIndex::check_storage_kind(StorageKind storage_kind) noexcept {
     if (!status.ok()) {
         return status;
     }
-    return supported ? Status_Ok
-                     : Status(
-                           ErrorCode::INVALID_ARGUMENT,
-                           "The specified storage kind is not compatible with the "
-                           "DynamicVamanaIndex"
-                       );
+    return supported
+               ? Status_Ok
+               : Status(
+                     ErrorCode::INVALID_ARGUMENT,
+                     "The specified storage kind is not compatible with the VamanaIndex"
+                 );
 }
 
 Status VamanaIndex::build(
@@ -180,6 +180,10 @@ Status VamanaIndexLeanVec::build(
     *index = nullptr;
 
     return runtime_error_wrapper([&] {
+        if (training_data == nullptr) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "Training data must not be null"};
+        }
         auto training_data_impl =
             static_cast<const LeanVecTrainingDataManager*>(training_data)->impl_;
         auto impl = std::make_unique<Impl>(
@@ -192,7 +196,7 @@ Status VamanaIndexLeanVec::build(
 #else  // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // LeanVec storage kind is not supported in this build configuration
 Status VamanaIndexLeanVec::
-    build(DynamicVamanaIndex**, size_t, MetricType, StorageKind, size_t, const DynamicVamanaIndex::BuildParams&, const DynamicVamanaIndex::SearchParams&, const DynamicVamanaIndex::DynamicIndexParams&) noexcept {
+    build(VamanaIndex**, size_t, MetricType, StorageKind, size_t, const VamanaIndex::BuildParams&, const VamanaIndex::SearchParams&) noexcept {
     return Status(
         ErrorCode::NOT_IMPLEMENTED,
         "DynamicVamanaIndexLeanVec is not supported in this build configuration."
@@ -200,7 +204,7 @@ Status VamanaIndexLeanVec::
 }
 
 Status VamanaIndexLeanVec::
-    build(DynamicVamanaIndex**, size_t, MetricType, StorageKind, size_t, const DynamicVamanaIndex::BuildParams&, const DynamicVamanaIndex::SearchParams&, const DynamicVamanaIndex::DynamicIndexParams&) noexcept {
+    build(VamanaIndex**, size_t, MetricType, StorageKind, const LeanVecTrainingData*, const VamanaIndex::BuildParams&, const VamanaIndex::SearchParams&) noexcept {
     return Status(
         ErrorCode::NOT_IMPLEMENTED,
         "DynamicVamanaIndexLeanVec is not supported in this build configuration."

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -19,6 +19,7 @@
 #include "svs/runtime/vamana_index.h"
 
 #include "svs_runtime_utils.h"
+#include "training_impl.h"
 
 #include <svs/core/data.h>
 #include <svs/core/distance.h>
@@ -27,7 +28,8 @@
 #include <svs/extensions/vamana/scalar.h>
 #include <svs/lib/file.h>
 #include <svs/lib/float16.h>
-#include <svs/orchestrators/dynamic_vamana.h>
+#include <svs/lib/memory.h>
+#include <svs/orchestrators/vamana.h>
 #include <svs/quantization/scalar/scalar.h>
 
 #include <algorithm>
@@ -38,36 +40,32 @@
 namespace svs {
 namespace runtime {
 
-// Dynamic Vamana index implementation
-class DynamicVamanaIndexImpl {
-    using allocator_type = svs::data::Blocked<svs::lib::Allocator<float>>;
+// Vamana index implementation
+class VamanaIndexImpl {
+    using allocator_type = svs::lib::Allocator<float>;
 
   public:
-    DynamicVamanaIndexImpl(
+    VamanaIndexImpl(
         size_t dim,
         MetricType metric,
         StorageKind storage_kind,
-        const VamanaIndex::BuildParams& params,
-        const VamanaIndex::SearchParams& default_search_params,
-        const VamanaIndex::DynamicIndexParams& dynamic_index_params
+        const VamanaIndex::BuildParams& build_params,
+        const VamanaIndex::SearchParams& default_search_params
     )
         : dim_{dim}
         , metric_type_{metric}
         , storage_kind_{storage_kind}
-        , build_params_{params}
-        , default_search_params_{default_search_params}
-        , dynamic_index_params_{dynamic_index_params} {
+        , build_params_{build_params}
+        , default_search_params_{default_search_params} {
         if (!storage::is_supported_storage_kind(storage_kind)) {
             throw StatusException{
                 ErrorCode::INVALID_ARGUMENT,
                 "The specified storage kind is not compatible with the "
-                "DynamicVamanaIndex"};
+                "VamanaIndex"};
         }
     }
 
-    size_t size() const { return impl_ ? impl_->size() : 0; }
-
-    size_t blocksize_bytes() const { return 1u << dynamic_index_params_.blocksize_exp; }
+    size_t size() const { return impl_ ? get_impl()->size() : 0; }
 
     size_t dimensions() const { return dim_; }
 
@@ -75,13 +73,14 @@ class DynamicVamanaIndexImpl {
 
     StorageKind get_storage_kind() const { return storage_kind_; }
 
-    void add(data::ConstSimpleDataView<float> data, std::span<const size_t> labels) {
+    void add(const data::ConstSimpleDataView<float>& data) {
         if (!impl_) {
-            auto blocksize_bytes = lib::PowerOfTwo(dynamic_index_params_.blocksize_exp);
-            return init_impl(data, labels, blocksize_bytes);
+            return init_impl(data);
         }
 
-        impl_->add_points(data, labels);
+        throw StatusException{
+            ErrorCode::INVALID_ARGUMENT,
+            "Vamana index does not support adding points after initialization"};
     }
 
     void search(
@@ -111,19 +110,19 @@ class DynamicVamanaIndexImpl {
 
         // Simple search
         if (filter == nullptr) {
-            impl_->search(result, queries, sp);
+            get_impl()->search(result, queries, sp);
             return;
         }
 
         // Selective search with IDSelector
-        auto old_sp = impl_->get_search_parameters();
-        impl_->set_search_parameters(sp);
+        auto old_sp = get_impl()->get_search_parameters();
+        get_impl()->set_search_parameters(sp);
 
         auto search_closure = [&](const auto& range, uint64_t SVS_UNUSED(tid)) {
             for (auto i : range) {
                 // For every query
                 auto query = queries.get_datum(i);
-                auto iterator = impl_->batch_iterator(query);
+                auto iterator = get_impl()->batch_iterator(query);
                 size_t found = 0;
                 do {
                     iterator.next(k);
@@ -154,7 +153,7 @@ class DynamicVamanaIndexImpl {
             threadpool, svs::threads::StaticPartition{queries.size()}, search_closure
         );
 
-        impl_->set_search_parameters(old_sp);
+        get_impl()->set_search_parameters(old_sp);
     }
 
     void range_search(
@@ -164,9 +163,6 @@ class DynamicVamanaIndexImpl {
         const VamanaIndex::SearchParams* params = nullptr,
         IDFilter* filter = nullptr
     ) const {
-        if (!impl_) {
-            throw StatusException{ErrorCode::NOT_INITIALIZED, "Index not initialized"};
-        }
         if (radius <= 0) {
             throw StatusException{
                 ErrorCode::INVALID_ARGUMENT, "radius must be greater than 0"};
@@ -178,8 +174,8 @@ class DynamicVamanaIndexImpl {
         }
 
         auto sp = make_search_parameters(params);
-        auto old_sp = impl_->get_search_parameters();
-        impl_->set_search_parameters(sp);
+        auto old_sp = get_impl()->get_search_parameters();
+        get_impl()->set_search_parameters(sp);
 
         // Using ResultHandler makes no sense due to it's complexity, overhead and
         // missed features; e.g. add_result() does not indicate whether result added
@@ -208,13 +204,15 @@ class DynamicVamanaIndexImpl {
 
         // Set iterator batch size to search window size
         auto batch_size = sp.buffer_config_.get_search_window_size();
+        // Ensure batch size is at least 10 to avoid excessive overhead of small batches
+        batch_size = std::max(batch_size, size_t(10));
 
         auto range_search_closure = [&](const auto& range, uint64_t SVS_UNUSED(tid)) {
             for (auto i : range) {
                 // For every query
                 auto query = queries.get_datum(i);
 
-                auto iterator = impl_->batch_iterator(query);
+                auto iterator = get_impl()->batch_iterator(query);
                 bool in_range = true;
 
                 do {
@@ -263,60 +261,12 @@ class DynamicVamanaIndexImpl {
             }
         }
 
-        impl_->set_search_parameters(old_sp);
+        get_impl()->set_search_parameters(old_sp);
     }
 
-    size_t remove(std::span<const size_t> labels) {
-        if (!impl_) {
-            throw StatusException{ErrorCode::NOT_INITIALIZED, "Index not initialized"};
-        }
-
-        // SVS deletion is a soft deletion, meaning the corresponding vectors are
-        // marked as deleted but still present in both the dataset and the graph,
-        // and will be navigated through during search.
-        // Actual cleanup happens once a large enough number of soft deleted vectors
-        // are collected.
-        impl_->delete_points(labels);
-        ntotal_soft_deleted += labels.size();
-
-        auto ntotal = impl_->size();
-        const float cleanup_threshold = .5f;
-        if (ntotal == 0 || (float)ntotal_soft_deleted / ntotal > cleanup_threshold) {
-            impl_->consolidate();
-            impl_->compact();
-            ntotal_soft_deleted = 0;
-        }
-        return labels.size();
-    }
-
-    size_t remove_selected(const IDFilter& selector) {
-        if (!impl_) {
-            throw StatusException{ErrorCode::NOT_INITIALIZED, "Index not initialized"};
-        }
-
-        auto ids = impl_->all_ids();
-        std::vector<size_t> ids_to_delete;
-        std::copy_if(
-            ids.begin(),
-            ids.end(),
-            std::back_inserter(ids_to_delete),
-            [&](size_t id) { return selector(id); }
-        );
-
-        return remove(ids_to_delete);
-    }
-
-    void reset() {
-        impl_.reset();
-        ntotal_soft_deleted = 0;
-    }
+    void reset() { impl_.reset(); }
 
     void save(std::ostream& out) const {
-        if (!impl_) {
-            throw StatusException{
-                ErrorCode::NOT_INITIALIZED, "Cannot serialize: SVS index not initialized."};
-        }
-
         lib::UniqueTempDirectory tempdir{"svs_vamana_save"};
         const auto config_dir = tempdir.get() / "config";
         const auto graph_dir = tempdir.get() / "graph";
@@ -324,12 +274,19 @@ class DynamicVamanaIndexImpl {
         std::filesystem::create_directories(config_dir);
         std::filesystem::create_directories(graph_dir);
         std::filesystem::create_directories(data_dir);
-        impl_->save(config_dir, graph_dir, data_dir);
+        get_impl()->save(config_dir, graph_dir, data_dir);
         lib::DirectoryArchiver::pack(tempdir, out);
     }
 
   protected:
     // Utility functions
+    svs::Vamana* get_impl() const {
+        if (!impl_) {
+            throw StatusException{ErrorCode::NOT_INITIALIZED, "Index not initialized"};
+        }
+        return impl_.get();
+    }
+
     svs::index::vamana::VamanaBuildParameters vamana_build_parameters() const {
         svs::index::vamana::VamanaBuildParameters result;
         set_if_specified(result.alpha, build_params_.alpha);
@@ -386,18 +343,16 @@ class DynamicVamanaIndexImpl {
     }
 
     template <typename Tag, typename... StorageArgs>
-    static svs::DynamicVamana* build_impl(
+    static svs::Vamana* build_impl(
         Tag&& tag,
         MetricType metric,
         const index::vamana::VamanaBuildParameters& parameters,
         const svs::data::ConstSimpleDataView<float>& data,
-        std::span<const size_t> labels,
-        svs::lib::PowerOfTwo blocksize_bytes,
         StorageArgs&&... storage_args
     ) {
         auto threadpool = default_threadpool();
         using storage_alloc_t = typename Tag::allocator_type;
-        auto allocator = storage::make_allocator<storage_alloc_t>(blocksize_bytes);
+        auto allocator = storage::make_allocator<storage_alloc_t>(svs::lib::PowerOfTwo{0});
 
         auto storage = make_storage(
             std::forward<Tag>(tag),
@@ -409,70 +364,56 @@ class DynamicVamanaIndexImpl {
 
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
         return distance_dispatcher([&](auto&& distance) {
-            return new svs::DynamicVamana(svs::DynamicVamana::build<float>(
+            return new svs::Vamana(svs::Vamana::build<float>(
                 parameters,
                 std::move(storage),
-                std::move(labels),
                 std::forward<decltype(distance)>(distance),
                 std::move(threadpool)
             ));
         });
     }
 
-    virtual void init_impl(
-        data::ConstSimpleDataView<float> data,
-        std::span<const size_t> labels,
-        lib::PowerOfTwo blocksize_bytes
-    ) {
+    virtual void init_impl(const data::ConstSimpleDataView<float>& data) {
         impl_.reset(storage::dispatch_storage_kind<allocator_type>(
             get_storage_kind(),
-            [this](
-                auto&& tag,
-                data::ConstSimpleDataView<float> data,
-                std::span<const size_t> labels,
-                lib::PowerOfTwo blocksize_bytes
-            ) {
+            [&](auto&& tag, const data::ConstSimpleDataView<float>& data) {
                 using Tag = std::decay_t<decltype(tag)>;
                 return build_impl(
                     std::forward<Tag>(tag),
                     this->metric_type_,
                     this->vamana_build_parameters(),
-                    data,
-                    labels,
-                    blocksize_bytes
+                    data
                 );
             },
-            data,
-            labels,
-            blocksize_bytes
+            data
         ));
+        get_impl()->set_search_parameters(make_search_parameters(&default_search_params_));
     }
 
     // Constructor used during loading
-    DynamicVamanaIndexImpl(
-        std::unique_ptr<svs::DynamicVamana>&& impl,
-        MetricType metric,
-        StorageKind storage_kind
+    VamanaIndexImpl(
+        std::unique_ptr<svs::Vamana>&& impl, MetricType metric, StorageKind storage_kind
     )
-        : impl_{std::move(impl)} {
-        dim_ = impl_->dimensions();
-        const auto& buffer_config = impl_->get_search_parameters().buffer_config_;
-        default_search_params_ = {
-            buffer_config.get_search_window_size(), buffer_config.get_total_capacity()};
-        metric_type_ = metric;
-        storage_kind_ = storage_kind;
-        build_params_ = VamanaIndex::BuildParams{
-            impl_->get_graph_max_degree(),
-            impl_->get_prune_to(),
-            impl_->get_alpha(),
-            impl_->get_construction_window_size(),
-            impl_->get_max_candidates(),
-            impl_->get_full_search_history()};
+        : metric_type_{metric}
+        , storage_kind_{storage_kind}
+        , impl_{std::move(impl)} {
+        if (impl_) {
+            dim_ = impl_->dimensions();
+            const auto& buffer_config = impl_->get_search_parameters().buffer_config_;
+            default_search_params_ = {
+                buffer_config.get_search_window_size(), buffer_config.get_total_capacity()};
+            build_params_ = VamanaIndex::BuildParams{
+                impl_->get_graph_max_degree(),
+                impl_->get_prune_to(),
+                impl_->get_alpha(),
+                impl_->get_construction_window_size(),
+                impl_->get_max_candidates(),
+                impl_->get_full_search_history()};
+        }
     }
 
     template <typename Tag>
-    static svs::DynamicVamana*
-    load_impl_t(Tag&& tag, std::istream& stream, MetricType metric) {
+    static svs::Vamana* load_impl_t(Tag&& tag, std::istream& stream, MetricType metric) {
         namespace fs = std::filesystem;
         lib::UniqueTempDirectory tempdir{"svs_vamana_load"};
         lib::DirectoryArchiver::unpack(stream, tempdir);
@@ -504,28 +445,27 @@ class DynamicVamanaIndexImpl {
         svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
 
         return distance_dispatcher([&](auto&& distance) {
-            return new svs::DynamicVamana(svs::DynamicVamana::assemble<float>(
+            return new svs::Vamana(svs::Vamana::assemble<float>(
                 config_path,
                 svs::GraphLoader{graph_path},
                 std::move(storage),
                 std::forward<decltype(distance)>(distance),
-                std::move(threadpool),
-                false
+                std::move(threadpool)
             ));
         });
     }
 
   public:
-    static DynamicVamanaIndexImpl*
+    static VamanaIndexImpl*
     load(std::istream& stream, MetricType metric, StorageKind storage_kind) {
         return storage::dispatch_storage_kind<allocator_type>(
             storage_kind,
             [&](auto&& tag, std::istream& stream, MetricType metric) {
                 using Tag = std::decay_t<decltype(tag)>;
-                std::unique_ptr<svs::DynamicVamana> impl{
+                std::unique_ptr<svs::Vamana> impl{
                     load_impl_t(std::forward<Tag>(tag), stream, metric)};
 
-                return new DynamicVamanaIndexImpl(std::move(impl), metric, storage_kind);
+                return new VamanaIndexImpl(std::move(impl), metric, storage_kind);
             },
             stream,
             metric
@@ -539,9 +479,112 @@ class DynamicVamanaIndexImpl {
     StorageKind storage_kind_;
     VamanaIndex::BuildParams build_params_;
     VamanaIndex::SearchParams default_search_params_;
-    VamanaIndex::DynamicIndexParams dynamic_index_params_;
-    std::unique_ptr<svs::DynamicVamana> impl_;
-    size_t ntotal_soft_deleted{0};
+    std::unique_ptr<svs::Vamana> impl_;
+};
+
+struct VamanaIndexLeanVecImpl : public VamanaIndexImpl {
+    using LeanVecMatricesType = LeanVecTrainingDataImpl::LeanVecMatricesType;
+    using allocator_type = svs::lib::Allocator<std::byte>;
+
+    VamanaIndexLeanVecImpl(
+        std::unique_ptr<svs::Vamana>&& impl, MetricType metric, StorageKind storage_kind
+    )
+        : VamanaIndexImpl{std::move(impl), metric, storage_kind}
+        , leanvec_dims_{0}
+        , leanvec_matrices_{std::nullopt} {
+        check_storage_kind(storage_kind);
+    }
+
+    VamanaIndexLeanVecImpl(
+        size_t dim,
+        MetricType metric,
+        StorageKind storage_kind,
+        const LeanVecTrainingDataImpl& training_data,
+        const VamanaIndex::BuildParams& params,
+        const VamanaIndex::SearchParams& default_search_params
+    )
+        : VamanaIndexImpl{dim, metric, storage_kind, params, default_search_params}
+        , leanvec_dims_{training_data.get_leanvec_dims()}
+        , leanvec_matrices_{training_data.get_leanvec_matrices()} {
+        check_storage_kind(storage_kind);
+    }
+
+    VamanaIndexLeanVecImpl(
+        size_t dim,
+        MetricType metric,
+        StorageKind storage_kind,
+        size_t leanvec_dims,
+        const VamanaIndex::BuildParams& params,
+        const VamanaIndex::SearchParams& default_search_params
+    )
+        : VamanaIndexImpl{dim, metric, storage_kind, params, default_search_params}
+        , leanvec_dims_{leanvec_dims}
+        , leanvec_matrices_{std::nullopt} {
+        check_storage_kind(storage_kind);
+    }
+
+    template <typename F, typename... Args>
+    static auto dispatch_leanvec_storage_kind(StorageKind kind, F&& f, Args&&... args) {
+        switch (kind) {
+            case StorageKind::LeanVec4x4:
+                return f(
+                    storage::StorageType<StorageKind::LeanVec4x4, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
+            case StorageKind::LeanVec4x8:
+                return f(
+                    storage::StorageType<StorageKind::LeanVec4x8, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
+            case StorageKind::LeanVec8x8:
+                return f(
+                    storage::StorageType<StorageKind::LeanVec8x8, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
+            default:
+                throw StatusException{
+                    ErrorCode::INVALID_ARGUMENT, "SVS LeanVec storage kind required"};
+        }
+    }
+
+    void init_impl(const data::ConstSimpleDataView<float>& data) override {
+        assert(storage::is_leanvec_storage(this->storage_kind_));
+        impl_.reset(dispatch_leanvec_storage_kind(
+            this->storage_kind_,
+            [&](auto&& tag, const data::ConstSimpleDataView<float>& data) {
+                using Tag = std::decay_t<decltype(tag)>;
+                return VamanaIndexImpl::build_impl(
+                    std::forward<Tag>(tag),
+                    this->metric_type_,
+                    this->vamana_build_parameters(),
+                    data,
+                    leanvec_dims_,
+                    leanvec_matrices_
+                );
+            },
+            data
+        ));
+        impl_->set_search_parameters(make_search_parameters(&default_search_params_));
+    }
+
+  protected:
+    size_t leanvec_dims_;
+    std::optional<LeanVecMatricesType> leanvec_matrices_;
+
+    StorageKind check_storage_kind(StorageKind kind) {
+        if (!storage::is_leanvec_storage(kind)) {
+            throw StatusException(
+                ErrorCode::INVALID_ARGUMENT, "SVS LeanVec storage kind required"
+            );
+        }
+        if (!svs::detail::lvq_leanvec_enabled()) {
+            throw StatusException(
+                ErrorCode::NOT_IMPLEMENTED,
+                "LeanVec storage kind requested but not supported by CPU"
+            );
+        }
+        return kind;
+    }
 };
 
 } // namespace runtime

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -19,7 +19,10 @@
 #include "svs/runtime/vamana_index.h"
 
 #include "svs_runtime_utils.h"
+
+#ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 #include "training_impl.h"
+#endif
 
 #include <svs/core/data.h>
 #include <svs/core/distance.h>
@@ -487,6 +490,7 @@ class VamanaIndexImpl {
     std::unique_ptr<svs::Vamana> impl_;
 };
 
+#ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 struct VamanaIndexLeanVecImpl : public VamanaIndexImpl {
     using LeanVecMatricesType = LeanVecTrainingDataImpl::LeanVecMatricesType;
     using allocator_type = svs::lib::Allocator<std::byte>;
@@ -591,6 +595,7 @@ struct VamanaIndexLeanVecImpl : public VamanaIndexImpl {
         return kind;
     }
 };
+#endif // SVS_RUNTIME_HAVE_LVQ_LEANVEC
 
 } // namespace runtime
 } // namespace svs

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -29,6 +29,7 @@
 #include <svs/lib/file.h>
 #include <svs/lib/float16.h>
 #include <svs/lib/memory.h>
+#include <svs/lib/scopeguard.h>
 #include <svs/orchestrators/vamana.h>
 #include <svs/quantization/scalar/scalar.h>
 
@@ -116,6 +117,9 @@ class VamanaIndexImpl {
 
         // Selective search with IDSelector
         auto old_sp = get_impl()->get_search_parameters();
+        auto sp_restore = svs::lib::make_scope_guard([&]() noexcept {
+            get_impl()->set_search_parameters(old_sp);
+        });
         get_impl()->set_search_parameters(sp);
 
         auto search_closure = [&](const auto& range, uint64_t SVS_UNUSED(tid)) {
@@ -139,10 +143,9 @@ class VamanaIndexImpl {
 
                 // Pad results if not enough neighbors found
                 if (found < k) {
-                    auto& dists = result.distances();
-                    std::fill(dists.begin() + found, dists.end(), Unspecify<float>());
-                    auto& inds = result.indices();
-                    std::fill(inds.begin() + found, inds.end(), Unspecify<size_t>());
+                    for (size_t j = found; j < k; ++j) {
+                        result.set(Neighbor{Unspecify<size_t>(), Unspecify<float>()}, i, j);
+                    }
                 }
             }
         };
@@ -152,8 +155,6 @@ class VamanaIndexImpl {
         svs::threads::parallel_for(
             threadpool, svs::threads::StaticPartition{queries.size()}, search_closure
         );
-
-        get_impl()->set_search_parameters(old_sp);
     }
 
     void range_search(
@@ -175,6 +176,9 @@ class VamanaIndexImpl {
 
         auto sp = make_search_parameters(params);
         auto old_sp = get_impl()->get_search_parameters();
+        auto sp_restore = svs::lib::make_scope_guard([&]() noexcept {
+            get_impl()->set_search_parameters(old_sp);
+        });
         get_impl()->set_search_parameters(sp);
 
         // Using ResultHandler makes no sense due to it's complexity, overhead and
@@ -260,8 +264,6 @@ class VamanaIndexImpl {
                 ofs++;
             }
         }
-
-        get_impl()->set_search_parameters(old_sp);
     }
 
     void reset() { impl_.reset(); }
@@ -352,7 +354,7 @@ class VamanaIndexImpl {
     ) {
         auto threadpool = default_threadpool();
         using storage_alloc_t = typename Tag::allocator_type;
-        auto allocator = storage::make_allocator<storage_alloc_t>(svs::lib::PowerOfTwo{0});
+        auto allocator = storage::make_allocator<storage_alloc_t>();
 
         auto storage = make_storage(
             std::forward<Tag>(tag),
@@ -394,8 +396,11 @@ class VamanaIndexImpl {
     VamanaIndexImpl(
         std::unique_ptr<svs::Vamana>&& impl, MetricType metric, StorageKind storage_kind
     )
-        : metric_type_{metric}
+        : dim_{0}
+        , metric_type_{metric}
         , storage_kind_{storage_kind}
+        , build_params_{}
+        , default_search_params_{}
         , impl_{std::move(impl)} {
         if (impl_) {
             dim_ = impl_->dimensions();

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -773,6 +773,7 @@ CATCH_TEST_CASE("StaticIndexLeanVecWithTrainingData", "[runtime][static_vamana]"
     svs::runtime::v0::Status training_status = svs::runtime::v0::LeanVecTrainingData::build(
         &training_data, test_d, test_n, test_data.data(), leanvec_dims
     );
+    CATCH_REQUIRE(training_status.ok());
 
     svs::runtime::v0::Status status = svs::runtime::v0::VamanaIndexLeanVec::build(
         &index,

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -770,18 +770,8 @@ CATCH_TEST_CASE("StaticIndexLeanVecWithTrainingData", "[runtime][static_vamana]"
 
     // Prepare training data
     svs::runtime::v0::LeanVecTrainingData* training_data = nullptr;
-    svs::runtime::v0::Status training_status = svs::runtime::v0::LeanVecTrainingData::build(
+    svs::runtime::v0::Status status = svs::runtime::v0::LeanVecTrainingData::build(
         &training_data, test_d, test_n, test_data.data(), leanvec_dims
-    );
-    CATCH_REQUIRE(training_status.ok());
-
-    svs::runtime::v0::Status status = svs::runtime::v0::VamanaIndexLeanVec::build(
-        &index,
-        test_d,
-        svs::runtime::v0::MetricType::L2,
-        svs::runtime::v0::StorageKind::LeanVec4x4,
-        training_data,
-        build_params
     );
     if (!svs::runtime::v0::VamanaIndexLeanVec::check_storage_kind(
              svs::runtime::v0::StorageKind::LeanVec4x4
@@ -790,6 +780,15 @@ CATCH_TEST_CASE("StaticIndexLeanVecWithTrainingData", "[runtime][static_vamana]"
         CATCH_REQUIRE(!status.ok());
         CATCH_SKIP("Storage kind is not supported, skipping test.");
     }
+
+    status = svs::runtime::v0::VamanaIndexLeanVec::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::LeanVec4x4,
+        training_data,
+        build_params
+    );
     CATCH_REQUIRE(status.ok());
     CATCH_REQUIRE(index != nullptr);
 

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -92,10 +92,9 @@ void write_and_read_index(
     svs::runtime::v0::Status status = build_func(&index);
 
     // Stop here if storage kind is not supported on this platform
-    if constexpr (std::is_same_v<Index, svs::runtime::v0::DynamicVamanaIndex>) {
+    if constexpr (std::is_base_of_v<svs::runtime::v0::VamanaIndex, Index>) {
         if (storage_kind.has_value()) {
-            if (!svs::runtime::v0::DynamicVamanaIndex::check_storage_kind(*storage_kind)
-                     .ok()) {
+            if (!Index::check_storage_kind(*storage_kind).ok()) {
                 CATCH_REQUIRE(!status.ok());
                 return;
             }
@@ -105,7 +104,7 @@ void write_and_read_index(
     CATCH_REQUIRE(index != nullptr);
 
     // Add data to index
-    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex>) {
+    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex> || std::is_same_v<Index, svs::runtime::v0::VamanaIndex>) {
         status = index->add(n, xb.data());
     } else {
         std::vector<size_t> labels(n);
@@ -674,4 +673,211 @@ CATCH_TEST_CASE("SetIfSpecifiedUtility", "[runtime]") {
         set_if_specified(target, false);
         CATCH_REQUIRE(target == false);
     }
+}
+
+CATCH_TEST_CASE("WriteAndReadStaticIndexSVS", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP32,
+            build_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP32
+    );
+}
+
+CATCH_TEST_CASE("WriteAndReadStaticIndexSVSFP16", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP16,
+            build_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP16
+    );
+}
+
+CATCH_TEST_CASE("WriteAndReadStaticIndexSVSSQI8", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::SQI8,
+            build_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::SQI8
+    );
+}
+
+CATCH_TEST_CASE("WriteAndReadStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LVQ4x4,
+            build_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LVQ4x4
+    );
+}
+
+CATCH_TEST_CASE("WriteAndReadStaticIndexSVSVamanaLeanVec4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndexLeanVec::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LeanVec4x4,
+            32,
+            build_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LeanVec4x4
+    );
+}
+
+CATCH_TEST_CASE("StaticIndexLeanVecWithTrainingData", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    const size_t leanvec_dims = 32;
+    // Build LeanVec index with explicit training
+    svs::runtime::v0::VamanaIndex* index = nullptr;
+    svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+
+    // Prepare training data
+    svs::runtime::v0::LeanVecTrainingData* training_data = nullptr;
+    svs::runtime::v0::Status training_status = svs::runtime::v0::LeanVecTrainingData::build(
+        &training_data, test_d, test_n, test_data.data(), leanvec_dims
+    );
+
+    svs::runtime::v0::Status status = svs::runtime::v0::VamanaIndexLeanVec::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::LeanVec4x4,
+        training_data,
+        build_params
+    );
+    if (!svs::runtime::v0::VamanaIndexLeanVec::check_storage_kind(
+             svs::runtime::v0::StorageKind::LeanVec4x4
+        )
+             .ok()) {
+        CATCH_REQUIRE(!status.ok());
+        CATCH_SKIP("Storage kind is not supported, skipping test.");
+    }
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    status = index->add(test_n, test_data.data());
+    CATCH_REQUIRE(status.ok());
+
+    svs::runtime::v0::VamanaIndex::destroy(index);
+    svs::runtime::v0::LeanVecTrainingData::destroy(training_data);
+}
+
+CATCH_TEST_CASE("SearchWithIDFilterStatic", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    // Build index
+    svs::runtime::v0::VamanaIndex* index = nullptr;
+    svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+    svs::runtime::v0::Status status = svs::runtime::v0::VamanaIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    // Add data
+    status = index->add(test_n, test_data.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Second attempt to add data should fail on static index
+    status = index->add(test_n, test_data.data());
+    CATCH_REQUIRE(!status.ok());
+
+    const int nq = 8;
+    const float* xq = test_data.data();
+    const int k = 10;
+
+    size_t min_id = test_n / 5;
+    size_t max_id = test_n * 4 / 5;
+    test_utils::IDFilterRange selector(min_id, max_id);
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    status = index->search(
+        nq, xq, k, distances.data(), result_labels.data(), nullptr, &selector
+    );
+    CATCH_REQUIRE(status.ok());
+
+    // All returned labels must fall inside the selected range
+    for (int i = 0; i < nq * k; ++i) {
+        CATCH_REQUIRE(result_labels[i] >= min_id);
+        CATCH_REQUIRE(result_labels[i] < max_id);
+    }
+
+    svs::runtime::v0::VamanaIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("RangeSearchFunctionalStatic", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    // Build index
+    svs::runtime::v0::VamanaIndex* index = nullptr;
+    svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+    svs::runtime::v0::Status status = svs::runtime::v0::VamanaIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    // Add data
+    status = index->add(test_n, test_data.data());
+    CATCH_REQUIRE(status.ok());
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+
+    // Small radius search
+    test_utils::TestResultsAllocator allocator_small;
+    status = index->range_search(nq, xq, 0.05f, allocator_small);
+    CATCH_REQUIRE(status.ok());
+
+    // Larger radius to exercise loop continuation
+    test_utils::TestResultsAllocator allocator_big;
+    status = index->range_search(nq, xq, 5.0f, allocator_big);
+    CATCH_REQUIRE(status.ok());
+
+    svs::runtime::v0::VamanaIndex::destroy(index);
 }

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -584,6 +584,9 @@ template <typename Alloc> class Blocked {
     Alloc allocator_{};
 };
 
+template <typename Alloc> inline constexpr bool is_blocked_v = false;
+template <typename Alloc> inline constexpr bool is_blocked_v<Blocked<Alloc>> = true;
+
 ///
 /// @brief A specialization of ``SimpleData`` for large-scale dynamic datasets.
 ///


### PR DESCRIPTION
## Enable static Vamana index functionality support in CPP Runtime API.

This PR includes following changes:
1. Refactored CPP Runtime storage factory utils to support configurable storage allocator.  
  * `StorageKindTag<Kind>` is removed and replaced with `StorageType<Kind, Alloc>` in usages
  * `Storagefactory::init()` `block_size` argument is replaced with `allocator` - to be constructed in index implementation code (with appropriate block size)
2. [static] `VamanaIndex` interface implementation.
3. Refactored IVF storage factory utils to match changes made in step 1.

