### PR TITLE
Revise SVS_CHECK_BOUNDS logic

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -82,10 +82,18 @@ option(SVS_EXPERIMENTAL_CLANG_TIDY
     OFF # disabled by default
 )
 
-option(SVS_EXPERIMENTAL_CHECK_BOUNDS
-    "Enable bounds checking on many data accesses."
-    OFF # diabled by default
-)
+# If not explicitly set by user, check bounds for non-release builds
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    option(SVS_EXPERIMENTAL_CHECK_BOUNDS
+        "Enable bounds checking on many data accesses."
+        OFF
+    )
+else()
+    option(SVS_EXPERIMENTAL_CHECK_BOUNDS
+        "Enable bounds checking on many data accesses."
+        ON
+    )
+endif()
 
 option(SVS_EXPERIMENTAL_ENABLE_NUMA
     "Enable NUMA aware data structures. (Experimental)"
@@ -126,8 +134,7 @@ if (SVS_NO_AVX512)
     target_compile_options(${SVS_LIB} INTERFACE -mno-avx512f)
 endif()
 
-# Enable bounds-checking by default for non-release builds.
-if (SVS_EXPERIMENTAL_CHECK_BOUNDS OR NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+if (SVS_EXPERIMENTAL_CHECK_BOUNDS)
     target_compile_definitions(${SVS_LIB} INTERFACE -DSVS_CHECK_BOUNDS=1)
 else()
     target_compile_definitions(${SVS_LIB} INTERFACE -DSVS_CHECK_BOUNDS=0)


### PR DESCRIPTION
  - Refactors `SVS_CHECK_BOUNDS` logic so that explicitly passing `SVS_EXPERIMENTAL_CHECK_BOUNDS` will trump any other settings, but not explicitly passing will lead to `SVS_CHECK_BOUNDS` depending on `CMAKE_BUILD_TYPE`
  - Previously, non-Release builds would force bounds checking on even when a user explicitly passed -`DSVS_EXPERIMENTAL_CHECK_BOUNDS=OFF`, but this now changes - see table below for more details
  - Updates docs to reflect the conditional default

  SVS_CHECK_BOUNDS value (current behavior)
<img width="599" height="72" alt="image" src="https://github.com/user-attachments/assets/1ec5cce8-4dee-47c0-95d5-35619a91a1b3" />


  SVS_CHECK_BOUNDS value (updated behavior)
<img width="599" height="73" alt="image" src="https://github.com/user-attachments/assets/f05e0bf6-c083-49b8-acdc-4eea9e272cc1" />