### PR TITLE
[MMAP] Add in-memory (mmap) stream index mapping.

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -123,7 +123,7 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
     else()
         # Links to LTO-enabled static library, requires GCC/G++ 11.2
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3")
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-06-1253.tar.gz"
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-21-1429.tar.gz"
                 CACHE STRING "URL to download SVS shared library")
         else()
             message(WARNING

--- a/bindings/cpp/include/svs/runtime/flat_index.h
+++ b/bindings/cpp/include/svs/runtime/flat_index.h
@@ -52,9 +52,8 @@ struct SVS_RUNTIME_API FlatIndex {
 
     // Load from a memory buffer.
     // The buffer is expected to be in the format produced by save().
-    static Status map_to_memory(
-        FlatIndex** index, const void* data, size_t size, MetricType metric
-    ) noexcept;
+    static Status
+    map_to_memory(FlatIndex** index, void* data, size_t size, MetricType metric) noexcept;
 };
 
 } // namespace v0

--- a/bindings/cpp/include/svs/runtime/flat_index.h
+++ b/bindings/cpp/include/svs/runtime/flat_index.h
@@ -44,6 +44,17 @@ struct SVS_RUNTIME_API FlatIndex {
 
     virtual Status save(std::ostream& out) const noexcept = 0;
     static Status load(FlatIndex** index, std::istream& in, MetricType metric) noexcept;
+
+    // Load from a memory-mapped file.
+    // The file is expected to be in the format produced by save().
+    static Status
+    map_to_file(FlatIndex** index, const char* path, MetricType metric) noexcept;
+
+    // Load from a memory buffer.
+    // The buffer is expected to be in the format produced by save().
+    static Status map_to_memory(
+        FlatIndex** index, const void* data, size_t size, MetricType metric
+    ) noexcept;
 };
 
 } // namespace v0

--- a/bindings/cpp/include/svs/runtime/vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/vamana_index.h
@@ -95,6 +95,22 @@ struct SVS_RUNTIME_API VamanaIndex {
     static Status load(
         VamanaIndex** index, std::istream& in, MetricType metric, StorageKind storage_kind
     ) noexcept;
+
+    // Load from a memory-mapped file.
+    // The file is expected to be in the format produced by save().
+    static Status map_to_file(
+        VamanaIndex** index, const char* path, MetricType metric, StorageKind storage_kind
+    ) noexcept;
+
+    // Load from a memory buffer.
+    // The buffer is expected to be in the format produced by save().
+    static Status map_to_memory(
+        VamanaIndex** index,
+        const void* data,
+        size_t size,
+        MetricType metric,
+        StorageKind storage_kind
+    ) noexcept;
 };
 
 struct SVS_RUNTIME_API VamanaIndexLeanVec : public VamanaIndex {

--- a/bindings/cpp/include/svs/runtime/vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/vamana_index.h
@@ -114,7 +114,7 @@ struct SVS_RUNTIME_API VamanaIndex {
     // The buffer is expected to be in the format produced by save().
     static Status map_to_memory(
         VamanaIndex** index,
-        const void* data,
+        void* data,
         size_t size,
         MetricType metric,
         StorageKind storage_kind

--- a/bindings/cpp/include/svs/runtime/vamana_index.h
+++ b/bindings/cpp/include/svs/runtime/vamana_index.h
@@ -103,6 +103,22 @@ struct SVS_RUNTIME_API VamanaIndex {
     static Status load(
         VamanaIndex** index, std::istream& in, MetricType metric, StorageKind storage_kind
     ) noexcept;
+
+    // Load from a memory-mapped file.
+    // The file is expected to be in the format produced by save().
+    static Status map_to_file(
+        VamanaIndex** index, const char* path, MetricType metric, StorageKind storage_kind
+    ) noexcept;
+
+    // Load from a memory buffer.
+    // The buffer is expected to be in the format produced by save().
+    static Status map_to_memory(
+        VamanaIndex** index,
+        const void* data,
+        size_t size,
+        MetricType metric,
+        StorageKind storage_kind
+    ) noexcept;
 };
 
 struct SVS_RUNTIME_API VamanaIndexLeanVec : public VamanaIndex {

--- a/bindings/cpp/src/flat_index.cpp
+++ b/bindings/cpp/src/flat_index.cpp
@@ -115,5 +115,34 @@ Status FlatIndex::load(FlatIndex** index, std::istream& in, MetricType metric) n
         return Status_Ok;
     });
 }
+
+Status
+FlatIndex::map_to_file(FlatIndex** index, const char* path, MetricType metric) noexcept {
+    *index = nullptr;
+    return runtime_error_wrapper([&] {
+        std::filesystem::path fs_path(path);
+        auto is = std::make_unique<svs::io::mmstream>(fs_path);
+        std::unique_ptr<FlatIndexImpl> impl{
+            FlatIndexImpl::map_to_stream(std::move(is), metric)};
+        *index = new FlatIndexManager{std::move(impl)};
+        return Status_Ok;
+    });
+}
+
+Status FlatIndex::map_to_memory(
+    FlatIndex** index, const void* data, size_t size, MetricType metric
+) noexcept {
+    *index = nullptr;
+    return runtime_error_wrapper([&] {
+        auto is = std::make_unique<std::istringstream>(
+            std::string(static_cast<const char*>(data), size)
+        );
+        std::unique_ptr<FlatIndexImpl> impl{
+            FlatIndexImpl::map_to_stream(std::move(is), metric)};
+        *index = new FlatIndexManager{std::move(impl)};
+        return Status_Ok;
+    });
+}
+
 } // namespace runtime
 } // namespace svs

--- a/bindings/cpp/src/flat_index.cpp
+++ b/bindings/cpp/src/flat_index.cpp
@@ -130,13 +130,12 @@ FlatIndex::map_to_file(FlatIndex** index, const char* path, MetricType metric) n
 }
 
 Status FlatIndex::map_to_memory(
-    FlatIndex** index, const void* data, size_t size, MetricType metric
+    FlatIndex** index, void* data, size_t size, MetricType metric
 ) noexcept {
     *index = nullptr;
     return runtime_error_wrapper([&] {
-        auto is = std::make_unique<std::istringstream>(
-            std::string(static_cast<const char*>(data), size)
-        );
+        auto sp = std::span(reinterpret_cast<char*>(data), size);
+        auto is = std::make_unique<svs::io::ispanstream>(sp);
         std::unique_ptr<FlatIndexImpl> impl{
             FlatIndexImpl::map_to_stream(std::move(is), metric)};
         *index = new FlatIndexManager{std::move(impl)};

--- a/bindings/cpp/src/flat_index_impl.h
+++ b/bindings/cpp/src/flat_index_impl.h
@@ -22,6 +22,7 @@
 
 #include <svs/core/data.h>
 #include <svs/core/distance.h>
+#include <svs/core/io/memstream.h>
 #include <svs/core/query_result.h>
 #include <svs/orchestrators/exhaustive.h>
 
@@ -111,12 +112,39 @@ class FlatIndexImpl {
         });
     }
 
+    static FlatIndexImpl*
+    map_to_stream(std::unique_ptr<std::istream>&& in, MetricType metric) {
+        if (!svs::io::is_memory_stream(*in)) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "Provided stream is not a memory stream"};
+        }
+        auto threadpool = default_threadpool();
+        using storage_type = svs::runtime::storage::
+            StorageType_t<StorageKind::FP32, svs::io::MemoryStreamAllocator<float>>;
+
+        svs::DistanceDispatcher distance_dispatcher(to_svs_distance(metric));
+        return distance_dispatcher([&](auto&& distance) {
+            auto impl = new svs::Flat{svs::Flat::assemble<float, storage_type>(
+                *in, std::forward<decltype(distance)>(distance), std::move(threadpool)
+            )};
+
+            return new FlatIndexImpl(
+                std::unique_ptr<svs::Flat>{impl}, metric, std::move(in)
+            );
+        });
+    }
+
   protected:
     // Constructor used during loading
-    FlatIndexImpl(std::unique_ptr<svs::Flat>&& impl, MetricType metric)
+    FlatIndexImpl(
+        std::unique_ptr<svs::Flat>&& impl,
+        MetricType metric,
+        std::unique_ptr<std::istream> mapped_stream = nullptr
+    )
         : dim_{impl->dimensions()}
         , metric_type_{metric}
-        , impl_{std::move(impl)} {}
+        , impl_{std::move(impl)}
+        , mapped_stream_{std::move(mapped_stream)} {}
 
     void init_impl(data::ConstSimpleDataView<float> data) {
         auto threadpool = default_threadpool();
@@ -139,6 +167,8 @@ class FlatIndexImpl {
     size_t dim_;
     MetricType metric_type_;
     std::unique_ptr<svs::Flat> impl_;
+    // For memory-mapping, we need to keep the stream alive as long as the index is alive
+    std::unique_ptr<std::istream> mapped_stream_;
 };
 } // namespace runtime
 } // namespace svs

--- a/bindings/cpp/src/vamana_index.cpp
+++ b/bindings/cpp/src/vamana_index.cpp
@@ -160,7 +160,7 @@ Status VamanaIndex::map_to_file(
 
 Status VamanaIndex::map_to_memory(
     VamanaIndex** index,
-    const void* data,
+    void* data,
     size_t size,
     MetricType metric,
     StorageKind storage_kind
@@ -168,9 +168,8 @@ Status VamanaIndex::map_to_memory(
     using Impl = VamanaIndexImpl;
     *index = nullptr;
     return runtime_error_wrapper([&] {
-        auto is = std::make_unique<std::istringstream>(
-            std::string(static_cast<const char*>(data), size)
-        );
+        auto sp = std::span(reinterpret_cast<char*>(data), size);
+        auto is = std::make_unique<svs::io::ispanstream>(sp);
         std::unique_ptr<Impl> impl{
             Impl::map_to_stream(std::move(is), metric, storage_kind)};
         *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};

--- a/bindings/cpp/src/vamana_index.cpp
+++ b/bindings/cpp/src/vamana_index.cpp
@@ -144,6 +144,39 @@ Status VamanaIndex::load(
     });
 }
 
+Status VamanaIndex::map_to_file(
+    VamanaIndex** index, const char* path, MetricType metric, StorageKind storage_kind
+) noexcept {
+    using Impl = VamanaIndexImpl;
+    *index = nullptr;
+    return runtime_error_wrapper([&] {
+        std::filesystem::path fs_path(path);
+        auto is = std::make_unique<svs::io::mmstream>(fs_path);
+        std::unique_ptr<Impl> impl{
+            Impl::map_to_stream(std::move(is), metric, storage_kind)};
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
+Status VamanaIndex::map_to_memory(
+    VamanaIndex** index,
+    const void* data,
+    size_t size,
+    MetricType metric,
+    StorageKind storage_kind
+) noexcept {
+    using Impl = VamanaIndexImpl;
+    *index = nullptr;
+    return runtime_error_wrapper([&] {
+        auto is = std::make_unique<std::istringstream>(
+            std::string(static_cast<const char*>(data), size)
+        );
+        std::unique_ptr<Impl> impl{
+            Impl::map_to_stream(std::move(is), metric, storage_kind)};
+        *index = new VamanaIndexManagerBase<Impl>{std::move(impl)};
+    });
+}
+
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC
 // Specialization to build LeanVec-based Vamana index with specified leanvec dims
 Status VamanaIndexLeanVec::build(

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -453,11 +453,12 @@ class VamanaIndexImpl {
         }
     }
 
-    template <StorageKind Kind, typename Alloc>
+    template <StorageKind Kind, typename Alloc, typename... Args>
     static svs::Vamana* load_impl_t(
         storage::StorageType<Kind, Alloc>&& SVS_UNUSED(tag),
         std::istream& stream,
-        MetricType metric
+        MetricType metric,
+        Args&&... args
     ) {
         if constexpr (!storage::is_supported_storage_kind_v<Kind>) {
             throw StatusException(
@@ -468,7 +469,10 @@ class VamanaIndexImpl {
             auto threadpool = default_threadpool();
 
             return new svs::Vamana(svs::Vamana::assemble<float, storage_type>(
-                stream, to_svs_distance(metric), std::move(threadpool)
+                stream,
+                to_svs_distance(metric),
+                std::move(threadpool),
+                std::forward<Args>(args)...
             ));
         }
     }
@@ -502,7 +506,9 @@ class VamanaIndexImpl {
             storage_kind,
             [&](auto&& tag, std::unique_ptr<std::istream>&& in, MetricType metric) {
                 using Tag = std::decay_t<decltype(tag)>;
-                auto impl = load_impl_t(std::forward<Tag>(tag), *in, metric);
+                auto impl = load_impl_t(
+                    std::forward<Tag>(tag), *in, metric, map_allocator_type{*in}
+                );
                 return new VamanaIndexImpl(
                     std::unique_ptr<svs::Vamana>{impl}, metric, storage_kind, std::move(in)
                 );

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -27,6 +27,7 @@
 #include <svs/core/data.h>
 #include <svs/core/distance.h>
 #include <svs/core/graph.h>
+#include <svs/core/io/memstream.h>
 #include <svs/core/query_result.h>
 #include <svs/extensions/vamana/scalar.h>
 #include <svs/lib/file.h>
@@ -425,14 +426,18 @@ class VamanaIndexImpl {
 
     // Constructor used during loading
     VamanaIndexImpl(
-        std::unique_ptr<svs::Vamana>&& impl, MetricType metric, StorageKind storage_kind
+        std::unique_ptr<svs::Vamana>&& impl,
+        MetricType metric,
+        StorageKind storage_kind,
+        std::unique_ptr<std::istream> mapped_stream = nullptr
     )
         : dim_{0}
         , metric_type_{metric}
         , storage_kind_{storage_kind}
         , build_params_{}
         , default_search_params_{}
-        , impl_{std::move(impl)} {
+        , impl_{std::move(impl)}
+        , mapped_stream_{std::move(mapped_stream)} {
         if (impl_) {
             dim_ = impl_->dimensions();
             const auto& buffer_config = impl_->get_search_parameters().buffer_config_;
@@ -485,6 +490,28 @@ class VamanaIndexImpl {
         );
     }
 
+    static VamanaIndexImpl* map_to_stream(
+        std::unique_ptr<std::istream>&& in, MetricType metric, StorageKind storage_kind
+    ) {
+        using map_allocator_type = svs::io::MemoryStreamAllocator<float>;
+        if (!svs::io::is_memory_stream(*in)) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "Provided stream is not a memory stream"};
+        }
+        return storage::dispatch_storage_kind<map_allocator_type>(
+            storage_kind,
+            [&](auto&& tag, std::unique_ptr<std::istream>&& in, MetricType metric) {
+                using Tag = std::decay_t<decltype(tag)>;
+                auto impl = load_impl_t(std::forward<Tag>(tag), *in, metric);
+                return new VamanaIndexImpl(
+                    std::unique_ptr<svs::Vamana>{impl}, metric, storage_kind, std::move(in)
+                );
+            },
+            std::move(in),
+            metric
+        );
+    }
+
     // Data members
   protected:
     size_t dim_;
@@ -493,6 +520,7 @@ class VamanaIndexImpl {
     VamanaIndex::BuildParams build_params_;
     VamanaIndex::SearchParams default_search_params_;
     std::unique_ptr<svs::Vamana> impl_;
+    std::unique_ptr<std::istream> mapped_stream_;
 };
 
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -27,6 +27,7 @@
 #include <svs/core/data.h>
 #include <svs/core/distance.h>
 #include <svs/core/graph.h>
+#include <svs/core/io/memstream.h>
 #include <svs/core/query_result.h>
 #include <svs/extensions/vamana/scalar.h>
 #include <svs/lib/file.h>
@@ -387,14 +388,18 @@ class VamanaIndexImpl {
 
     // Constructor used during loading
     VamanaIndexImpl(
-        std::unique_ptr<svs::Vamana>&& impl, MetricType metric, StorageKind storage_kind
+        std::unique_ptr<svs::Vamana>&& impl,
+        MetricType metric,
+        StorageKind storage_kind,
+        std::unique_ptr<std::istream> mapped_stream = nullptr
     )
         : dim_{0}
         , metric_type_{metric}
         , storage_kind_{storage_kind}
         , build_params_{}
         , default_search_params_{}
-        , impl_{std::move(impl)} {
+        , impl_{std::move(impl)}
+        , mapped_stream_{std::move(mapped_stream)} {
         if (impl_) {
             dim_ = impl_->dimensions();
             const auto& buffer_config = impl_->get_search_parameters().buffer_config_;
@@ -447,6 +452,28 @@ class VamanaIndexImpl {
         );
     }
 
+    static VamanaIndexImpl* map_to_stream(
+        std::unique_ptr<std::istream>&& in, MetricType metric, StorageKind storage_kind
+    ) {
+        using map_allocator_type = svs::io::MemoryStreamAllocator<float>;
+        if (!svs::io::is_memory_stream(*in)) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "Provided stream is not a memory stream"};
+        }
+        return storage::dispatch_storage_kind<map_allocator_type>(
+            storage_kind,
+            [&](auto&& tag, std::unique_ptr<std::istream>&& in, MetricType metric) {
+                using Tag = std::decay_t<decltype(tag)>;
+                auto impl = load_impl_t(std::forward<Tag>(tag), *in, metric);
+                return new VamanaIndexImpl(
+                    std::unique_ptr<svs::Vamana>{impl}, metric, storage_kind, std::move(in)
+                );
+            },
+            std::move(in),
+            metric
+        );
+    }
+
     // Data members
   protected:
     size_t dim_;
@@ -455,6 +482,7 @@ class VamanaIndexImpl {
     VamanaIndex::BuildParams build_params_;
     VamanaIndex::SearchParams default_search_params_;
     std::unique_ptr<svs::Vamana> impl_;
+    std::unique_ptr<std::istream> mapped_stream_;
 };
 
 #ifdef SVS_RUNTIME_HAVE_LVQ_LEANVEC

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -211,7 +211,6 @@ void write_and_map_index(
         CATCH_REQUIRE(storage_kind.has_value());
         status = Index::map_to_file(&loaded, filename.c_str(), metric, *storage_kind);
     }
-    CATCH_REQUIRE(std::string(status.message()) == "");
     CATCH_REQUIRE(status.ok());
     CATCH_REQUIRE(loaded != nullptr);
 

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -155,6 +155,82 @@ void write_and_read_index(
     Index::destroy(loaded);
 }
 
+// Template function to write and map an index
+template <typename Index, typename BuildFunc>
+void write_and_map_index(
+    BuildFunc build_func,
+    const std::vector<float>& xb,
+    size_t n,
+    size_t d,
+    std::optional<svs::runtime::v0::StorageKind> storage_kind = std::nullopt,
+    svs::runtime::v0::MetricType metric = svs::runtime::v0::MetricType::L2
+) {
+    // Build index
+    Index* index = nullptr;
+    svs::runtime::v0::Status status = build_func(&index);
+
+    // Stop here if storage kind is not supported on this platform
+    if constexpr (std::is_base_of_v<svs::runtime::v0::VamanaIndex, Index>) {
+        if (storage_kind.has_value()) {
+            if (!Index::check_storage_kind(*storage_kind).ok()) {
+                CATCH_REQUIRE(!status.ok());
+                return;
+            }
+        }
+    }
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    // Add data to index
+    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex> || std::is_same_v<Index, svs::runtime::v0::VamanaIndex>) {
+        status = index->add(n, xb.data());
+    } else {
+        std::vector<size_t> labels(n);
+        std::iota(labels.begin(), labels.end(), 0);
+        status = index->add(n, labels.data(), xb.data());
+    }
+    CATCH_REQUIRE(status.ok());
+
+    svs_test::prepare_temp_directory();
+    auto temp_dir = svs_test::temp_directory();
+    auto filename = temp_dir / "index_test.bin";
+
+    // Serialize
+    std::ofstream out(filename, std::ios::binary);
+    CATCH_REQUIRE(out.is_open());
+    status = index->save(out);
+    CATCH_REQUIRE(status.ok());
+    out.close();
+
+    // Deserialize
+    Index* loaded = nullptr;
+
+    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex>) {
+        status = Index::map_to_file(&loaded, filename.c_str(), metric);
+    } else {
+        CATCH_REQUIRE(storage_kind.has_value());
+        status = Index::map_to_file(&loaded, filename.c_str(), metric, *storage_kind);
+    }
+    CATCH_REQUIRE(std::string(status.message()) == "");
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(loaded != nullptr);
+
+    // Test basic functionality of loaded index
+    const int nq = 5;
+    const float* xq = xb.data();
+    const int k = 10;
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    status = loaded->search(nq, xq, k, distances.data(), result_labels.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Clean up
+    Index::destroy(index);
+    Index::destroy(loaded);
+}
+
 // Helper that writes and reads and index of requested size
 // Reports memory usage
 UsageInfo run_save_and_load_test(
@@ -455,6 +531,16 @@ CATCH_TEST_CASE("FlatIndexWriteAndRead", "[runtime]") {
     );
 }
 
+CATCH_TEST_CASE("FlatIndexWriteAndMap", "[runtime]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::FlatIndex** index) {
+        return svs::runtime::v0::FlatIndex::build(
+            index, test_d, svs::runtime::v0::MetricType::L2
+        );
+    };
+    write_and_map_index<svs::runtime::v0::FlatIndex>(build_func, test_data, test_n, test_d);
+}
+
 CATCH_TEST_CASE("SearchWithIDFilter", "[runtime]") {
     const auto& test_data = get_test_data();
     // Build index
@@ -692,6 +778,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVS", "[runtime][static_vamana]") {
     );
 }
 
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVS", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP32,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP32
+    );
+}
+
 CATCH_TEST_CASE("WriteAndReadStaticIndexSVSFP16", "[runtime][static_vamana]") {
     const auto& test_data = get_test_data();
     auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
@@ -705,6 +808,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSFP16", "[runtime][static_vamana]") {
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP16
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSFP16", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP16,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP16
     );
 }
@@ -726,6 +846,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSSQI8", "[runtime][static_vamana]") {
     );
 }
 
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSSQI8", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::SQI8,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::SQI8
+    );
+}
+
 CATCH_TEST_CASE("WriteAndReadStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") {
     const auto& test_data = get_test_data();
     auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
@@ -739,6 +876,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") 
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LVQ4x4
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LVQ4x4,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LVQ4x4
     );
 }
@@ -757,6 +911,24 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSVamanaLeanVec4x4", "[runtime][static_
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LeanVec4x4
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSVamanaLeanVec4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndexLeanVec::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LeanVec4x4,
+            32,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LeanVec4x4
     );
 }

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -155,6 +155,82 @@ void write_and_read_index(
     Index::destroy(loaded);
 }
 
+// Template function to write and map an index
+template <typename Index, typename BuildFunc>
+void write_and_map_index(
+    BuildFunc build_func,
+    const std::vector<float>& xb,
+    size_t n,
+    size_t d,
+    std::optional<svs::runtime::v0::StorageKind> storage_kind = std::nullopt,
+    svs::runtime::v0::MetricType metric = svs::runtime::v0::MetricType::L2
+) {
+    // Build index
+    Index* index = nullptr;
+    svs::runtime::v0::Status status = build_func(&index);
+
+    // Stop here if storage kind is not supported on this platform
+    if constexpr (std::is_base_of_v<svs::runtime::v0::VamanaIndex, Index>) {
+        if (storage_kind.has_value()) {
+            if (!Index::check_storage_kind(*storage_kind).ok()) {
+                CATCH_REQUIRE(!status.ok());
+                return;
+            }
+        }
+    }
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    // Add data to index
+    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex> || std::is_same_v<Index, svs::runtime::v0::VamanaIndex>) {
+        status = index->add(n, xb.data());
+    } else {
+        std::vector<size_t> labels(n);
+        std::iota(labels.begin(), labels.end(), 0);
+        status = index->add(n, labels.data(), xb.data());
+    }
+    CATCH_REQUIRE(status.ok());
+
+    svs_test::prepare_temp_directory();
+    auto temp_dir = svs_test::temp_directory();
+    auto filename = temp_dir / "index_test.bin";
+
+    // Serialize
+    std::ofstream out(filename, std::ios::binary);
+    CATCH_REQUIRE(out.is_open());
+    status = index->save(out);
+    CATCH_REQUIRE(status.ok());
+    out.close();
+
+    // Deserialize
+    Index* loaded = nullptr;
+
+    if constexpr (std::is_same_v<Index, svs::runtime::v0::FlatIndex>) {
+        status = Index::map_to_file(&loaded, filename.c_str(), metric);
+    } else {
+        CATCH_REQUIRE(storage_kind.has_value());
+        status = Index::map_to_file(&loaded, filename.c_str(), metric, *storage_kind);
+    }
+    CATCH_REQUIRE(std::string(status.message()) == "");
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(loaded != nullptr);
+
+    // Test basic functionality of loaded index
+    const int nq = 5;
+    const float* xq = xb.data();
+    const int k = 10;
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    status = loaded->search(nq, xq, k, distances.data(), result_labels.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Clean up
+    Index::destroy(index);
+    Index::destroy(loaded);
+}
+
 // Helper that writes and reads and index of requested size
 // Reports memory usage
 UsageInfo run_save_and_load_test(
@@ -453,6 +529,16 @@ CATCH_TEST_CASE("FlatIndexWriteAndRead", "[runtime]") {
     write_and_read_index<svs::runtime::v0::FlatIndex>(
         build_func, test_data, test_n, test_d
     );
+}
+
+CATCH_TEST_CASE("FlatIndexWriteAndMap", "[runtime]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::FlatIndex** index) {
+        return svs::runtime::v0::FlatIndex::build(
+            index, test_d, svs::runtime::v0::MetricType::L2
+        );
+    };
+    write_and_map_index<svs::runtime::v0::FlatIndex>(build_func, test_data, test_n, test_d);
 }
 
 CATCH_TEST_CASE("SearchWithIDFilter", "[runtime]") {
@@ -808,6 +894,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVS", "[runtime][static_vamana]") {
     );
 }
 
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVS", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP32,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP32
+    );
+}
+
 CATCH_TEST_CASE("WriteAndReadStaticIndexSVSFP16", "[runtime][static_vamana]") {
     const auto& test_data = get_test_data();
     auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
@@ -821,6 +924,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSFP16", "[runtime][static_vamana]") {
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP16
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSFP16", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::FP16,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::FP16
     );
 }
@@ -842,6 +962,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSSQI8", "[runtime][static_vamana]") {
     );
 }
 
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSSQI8", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::SQI8,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::SQI8
+    );
+}
+
 CATCH_TEST_CASE("WriteAndReadStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") {
     const auto& test_data = get_test_data();
     auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
@@ -855,6 +992,23 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") 
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LVQ4x4
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSLVQ4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndex::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LVQ4x4,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LVQ4x4
     );
 }
@@ -873,6 +1027,24 @@ CATCH_TEST_CASE("WriteAndReadStaticIndexSVSVamanaLeanVec4x4", "[runtime][static_
         );
     };
     write_and_read_index<svs::runtime::v0::VamanaIndex>(
+        build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LeanVec4x4
+    );
+}
+
+CATCH_TEST_CASE("WriteAndMapStaticIndexSVSVamanaLeanVec4x4", "[runtime][static_vamana]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::VamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        return svs::runtime::v0::VamanaIndexLeanVec::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LeanVec4x4,
+            32,
+            build_params
+        );
+    };
+    write_and_map_index<svs::runtime::v0::VamanaIndex>(
         build_func, test_data, test_n, test_d, svs::runtime::v0::StorageKind::LeanVec4x4
     );
 }

--- a/bindings/cpp/tests/utils.h
+++ b/bindings/cpp/tests/utils.h
@@ -30,29 +30,51 @@ namespace svs_test {
 ///// File System
 /////
 
-inline std::filesystem::path temp_directory() {
+namespace detail {
+struct TempDirectory {
+    std::filesystem::path path;
+
+    explicit TempDirectory(const std::string& prefix)
+        : path{create_unique_temp_directory(prefix)} {}
+
+    ~TempDirectory() noexcept {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+        // Ignore errors in cleanup.
+    }
+
+    std::filesystem::path get() const { return path; }
+    operator const std::filesystem::path&() const { return path; }
+
+    std::filesystem::path operator/(const std::string& subpath) const {
+        return path / subpath;
+    }
+
+    static std::filesystem::path create_unique_temp_directory(const std::string& prefix) {
+        namespace fs = std::filesystem;
+        auto temp_dir = fs::temp_directory_path();
+        constexpr int hex_mask = 0xFFFFFF; // 6 hex digits is enough.
+        // Try up to 10 times to create a unique directory.
+        for (int i = 0; i < 10; ++i) {
+            auto random_hex = std::to_string(std::rand() & hex_mask);
+            auto dir = temp_dir / (prefix + "-" + random_hex);
+            if (std::filesystem::create_directories(dir)) {
+                return dir;
+            }
+        }
+        throw std::runtime_error("Could not create a unique temporary directory!");
+    }
+};
+} // namespace detail
+
+inline detail::TempDirectory temp_directory() {
     // Use /tmp for runtime binding tests
-    return std::filesystem::path("/tmp/svs_runtime_test");
+    return detail::TempDirectory("svs_runtime_test");
 }
 
-inline bool cleanup_temp_directory() {
-    return std::filesystem::remove_all(temp_directory());
-}
+inline bool prepare_temp_directory() { return true; }
 
-inline bool make_temp_directory() {
-    return std::filesystem::create_directories(temp_directory());
-}
-
-inline bool prepare_temp_directory() {
-    cleanup_temp_directory();
-    return make_temp_directory();
-}
-
-inline std::filesystem::path prepare_temp_directory_v2() {
-    cleanup_temp_directory();
-    make_temp_directory();
-    return temp_directory();
-}
+inline detail::TempDirectory prepare_temp_directory_v2() { return temp_directory(); }
 
 } // namespace svs_test
 

--- a/include/svs/core/data/io.h
+++ b/include/svs/core/data/io.h
@@ -114,9 +114,9 @@ void populate(Data& data, WriteAccessor& accessor, const File& file) {
     populate_impl(data, accessor, file, default_populate_tag);
 }
 
-template <typename T> [[nodiscard]] size_t streaming_size(const T& obj) noexcept;
+template <typename T> [[nodiscard]] size_t streaming_size(const T&) noexcept;
 
-template <HasDataType T> [[nodiscard]] size_t streaming_size(const T& obj) noexcept {
+template <HasDataType T> [[nodiscard]] size_t streaming_size(const T&) noexcept {
     return element_size(datatype_v<T>);
 }
 

--- a/include/svs/core/data/io.h
+++ b/include/svs/core/data/io.h
@@ -19,6 +19,7 @@
 // svs
 #include "svs/concepts/data.h"
 #include "svs/core/io.h"
+#include "svs/core/io/memstream.h"
 
 #include "svs/lib/array.h"
 #include "svs/lib/exception.h"
@@ -113,6 +114,34 @@ void populate(Data& data, WriteAccessor& accessor, const File& file) {
     populate_impl(data, accessor, file, default_populate_tag);
 }
 
+template <typename T> [[nodiscard]] size_t streaming_size(const T& obj) noexcept;
+
+template <HasDataType T> [[nodiscard]] size_t streaming_size(const T& obj) noexcept {
+    return element_size(datatype_v<T>);
+}
+
+template <typename T, typename Alloc = ::std::allocator<T>>
+[[nodiscard]] size_t streaming_size(const ::std::vector<T, Alloc>& vec) noexcept {
+    return vec.size() * streaming_size(T{});
+}
+
+template <typename T, size_t N>
+[[nodiscard]] size_t streaming_size(const ::std::array<T, N>& arr) noexcept {
+    return arr.size() * streaming_size(T{});
+}
+
+template <typename... Ts>
+[[nodiscard]] size_t streaming_size(const ::std::tuple<Ts...>& tup) noexcept {
+    size_t total = 0;
+    lib::foreach (tup, [&](const auto& x) { total += streaming_size(x); });
+    return total;
+}
+
+template <typename T, typename Dims, typename Alloc = lib::Allocator<T>>
+[[nodiscard]] size_t streaming_size(const svs::DenseArray<T, Dims, Alloc>& arr) noexcept {
+    return arr.size() * streaming_size(T{});
+}
+
 /////
 ///// Saving
 /////
@@ -199,6 +228,25 @@ lib::lazy_result_t<F, size_t, size_t>
 load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
     auto data = lazy(num_vectors, dims);
     populate(is, data);
+    return data;
+}
+
+template <typename T, lib::LazyInvocable<size_t, size_t, T*> F>
+lib::lazy_result_t<F, size_t, size_t, T*>
+load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
+    // If the allocator is vew, we should support in_memory_stream only since views are only
+    // compatible with memory-mapped data.
+    if (!is_memory_stream(is)) {
+        throw ANNEXCEPTION(
+            "Trying to load a dataset with a view allocator from a non-memory stream. This "
+            "is not supported since views are compatible only with memory-mapped streams."
+        );
+    }
+    // If the allocator is a view, we need to construct the view with the correct pointer.
+    auto data = lazy(num_vectors, dims, io::current_ptr<T>(is));
+    // Then we stream have to be seeked past the data we just loaded since the view will not
+    // take ownership of the stream's position.
+    is.seekg(streaming_size(data), std::ios_base::cur);
     return data;
 }
 

--- a/include/svs/core/data/io.h
+++ b/include/svs/core/data/io.h
@@ -47,6 +47,11 @@ struct DefaultWriteAccessor {
         return file.reader(lib::Type<T>());
     }
 
+    template <data::MemoryDataset Data>
+    lib::VectorReader<typename Data::element_type> vector_reader(const Data& data) const {
+        return lib::VectorReader<typename Data::element_type>(data.dimensions());
+    }
+
     template <data::MemoryDataset Data, lib::AnySpanLike Span>
     void set(Data& data, size_t i, Span span) const {
         data.set_datum(i, span);
@@ -80,16 +85,13 @@ void populate_impl(
     }
 }
 
-template <data::MemoryDataset Data> void populate(std::istream& is, Data& data) {
-    auto accessor = DefaultWriteAccessor();
-
+template <data::MemoryDataset Data, typename WriteAccessor>
+void populate(Data& data, WriteAccessor&& accessor, std::istream& is) {
     size_t num_vectors = data.size();
-    size_t dims = data.dimensions();
-
     auto max_lines = Dynamic;
     auto nvectors = std::min(num_vectors, max_lines);
 
-    auto reader = lib::VectorReader<typename Data::element_type>(dims);
+    auto reader = accessor.vector_reader(data);
     for (size_t i = 0; i < nvectors; ++i) {
         reader.read(is);
         accessor.set(data, i, reader.data());
@@ -195,12 +197,17 @@ lib::lazy_result_t<F, size_t, size_t> load_dataset(const File& file, const F& la
     return load_impl(detail::to_native(file), default_accessor, lazy);
 }
 
-template <lib::LazyInvocable<size_t, size_t> F>
-lib::lazy_result_t<F, size_t, size_t>
-load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
+template <typename WriteAccessor, lib::LazyInvocable<size_t, size_t> F>
+lib::lazy_result_t<F, size_t, size_t> load_dataset(
+    std::istream& is,
+    WriteAccessor&& accessor,
+    const F& lazy,
+    size_t num_vectors,
+    size_t dims
+) {
     auto data = lazy(num_vectors, dims);
     if constexpr (!is_view_type_v<typename std::decay_t<decltype(data)>::allocator_type>) {
-        populate(is, data);
+        populate(data, std::forward<WriteAccessor>(accessor), is);
     } else {
         if (!is_memory_stream(is)) {
             throw ANNEXCEPTION("Trying to load a dataset with a view allocator from a "
@@ -210,6 +217,13 @@ load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
         }
     }
     return data;
+}
+
+template <lib::LazyInvocable<size_t, size_t> F>
+lib::lazy_result_t<F, size_t, size_t>
+load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
+    auto accessor = DefaultWriteAccessor();
+    return load_dataset(is, accessor, lazy, num_vectors, dims);
 }
 
 // Return whether or not a file is directly loadable via file-extension.

--- a/include/svs/core/data/io.h
+++ b/include/svs/core/data/io.h
@@ -114,34 +114,6 @@ void populate(Data& data, WriteAccessor& accessor, const File& file) {
     populate_impl(data, accessor, file, default_populate_tag);
 }
 
-template <typename T> [[nodiscard]] size_t streaming_size(const T&) noexcept;
-
-template <HasDataType T> [[nodiscard]] size_t streaming_size(const T&) noexcept {
-    return element_size(datatype_v<T>);
-}
-
-template <typename T, typename Alloc = ::std::allocator<T>>
-[[nodiscard]] size_t streaming_size(const ::std::vector<T, Alloc>& vec) noexcept {
-    return vec.size() * streaming_size(T{});
-}
-
-template <typename T, size_t N>
-[[nodiscard]] size_t streaming_size(const ::std::array<T, N>& arr) noexcept {
-    return arr.size() * streaming_size(T{});
-}
-
-template <typename... Ts>
-[[nodiscard]] size_t streaming_size(const ::std::tuple<Ts...>& tup) noexcept {
-    size_t total = 0;
-    lib::foreach (tup, [&](const auto& x) { total += streaming_size(x); });
-    return total;
-}
-
-template <typename T, typename Dims, typename Alloc = lib::Allocator<T>>
-[[nodiscard]] size_t streaming_size(const svs::DenseArray<T, Dims, Alloc>& arr) noexcept {
-    return arr.size() * streaming_size(T{});
-}
-
 /////
 ///// Saving
 /////
@@ -227,26 +199,16 @@ template <lib::LazyInvocable<size_t, size_t> F>
 lib::lazy_result_t<F, size_t, size_t>
 load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
     auto data = lazy(num_vectors, dims);
-    populate(is, data);
-    return data;
-}
-
-template <typename T, lib::LazyInvocable<size_t, size_t, T*> F>
-lib::lazy_result_t<F, size_t, size_t, T*>
-load_dataset(std::istream& is, const F& lazy, size_t num_vectors, size_t dims) {
-    // If the allocator is vew, we should support in_memory_stream only since views are only
-    // compatible with memory-mapped data.
-    if (!is_memory_stream(is)) {
-        throw ANNEXCEPTION(
-            "Trying to load a dataset with a view allocator from a non-memory stream. This "
-            "is not supported since views are compatible only with memory-mapped streams."
-        );
+    if constexpr (!is_view_type_v<typename std::decay_t<decltype(data)>::allocator_type>) {
+        populate(is, data);
+    } else {
+        if (!is_memory_stream(is)) {
+            throw ANNEXCEPTION("Trying to load a dataset with a view allocator from a "
+                               "non-memory stream. This "
+                               "is not supported since views are compatible only with "
+                               "memory-mapped streams.");
+        }
     }
-    // If the allocator is a view, we need to construct the view with the correct pointer.
-    auto data = lazy(num_vectors, dims, io::current_ptr<T>(is));
-    // Then we stream have to be seeked past the data we just loaded since the view will not
-    // take ownership of the stream's position.
-    is.seekg(streaming_size(data), std::ios_base::cur);
     return data;
 }
 

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -491,9 +491,10 @@ class SimpleData {
     static SimpleData load(const lib::LoadTable& SVS_UNUSED(table))
         requires(is_view)
     {
-        throw ANNEXCEPTION("Trying to load a SimpleData view without an istream. This is "
-                           "not supported since "
-                           "views are compatible only with memory-mapped streams.");
+        throw ANNEXCEPTION(
+            "Trying to load a SimpleData view without an istream. This is not supported "
+            "since views are compatible only with in-memory streams."
+        );
     }
 
     static SimpleData load(const lib::ContextFreeLoadTable& table, std::istream& is)
@@ -505,8 +506,8 @@ class SimpleData {
         );
         if (!io::is_memory_stream(is)) {
             throw ANNEXCEPTION(
-                "Trying to load a SimpleData view from a non-mmstream istream. This is not "
-                "supported since views are compatible only with memory-mapped streams."
+                "Trying to load a SimpleData view from a non-memory stream istream. This "
+                "is not supported since views are compatible only with in-memory streams."
             );
         }
 

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -474,20 +474,6 @@ class SimpleData {
         );
     }
 
-    static SimpleData load(
-        const lib::ContextFreeLoadTable& table,
-        std::istream& is,
-        const allocator_type& allocator = {}
-    )
-        requires(!is_view)
-    {
-        return GenericSerializer::load<T>(
-            table, is, lib::Lazy([&](size_t n_elements, size_t n_dimensions) {
-                return SimpleData(n_elements, n_dimensions, allocator);
-            })
-        );
-    }
-
     static SimpleData load(const lib::LoadTable& SVS_UNUSED(table))
         requires(is_view)
     {
@@ -495,6 +481,24 @@ class SimpleData {
             "Trying to load a SimpleData view without an istream. This is not supported "
             "since views are compatible only with in-memory streams."
         );
+    }
+
+    static SimpleData load(
+        const lib::ContextFreeLoadTable& table,
+        std::istream& is,
+        const allocator_type& allocator
+    ) {
+        return GenericSerializer::load<T>(
+            table, is, lib::Lazy([&](size_t n_elements, size_t n_dimensions) {
+                return SimpleData(n_elements, n_dimensions, allocator);
+            })
+        );
+    }
+
+    static SimpleData load(const lib::ContextFreeLoadTable& table, std::istream& is)
+        requires(!is_view)
+    {
+        return load(table, is, allocator_type{});
     }
 
     static SimpleData load(const lib::ContextFreeLoadTable& table, std::istream& is)
@@ -510,13 +514,7 @@ class SimpleData {
                 "is not supported since views are compatible only with in-memory streams."
             );
         }
-
-        allocator_type allocator(is);
-        return GenericSerializer::load<T>(
-            table, is, lib::Lazy([&](size_t n_elements, size_t n_dimensions) {
-                return SimpleData(n_elements, n_dimensions, allocator);
-            })
-        );
+        return load(table, is, allocator_type{is});
     }
 
     ///

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -21,6 +21,7 @@
 #include "svs/core/allocator.h"
 #include "svs/core/compact.h"
 #include "svs/core/data/io.h"
+#include "svs/core/io/memstream.h"
 
 #include "svs/lib/array.h"
 #include "svs/lib/boundscheck.h"
@@ -152,6 +153,25 @@ class GenericSerializer {
         size_t dims = lib::load_at<size_t>(table, "dims");
 
         return io::load_dataset(is, lazy, num_vectors, dims);
+    }
+
+    template <typename T, lib::LazyInvocable<size_t, size_t, T*> F>
+    static lib::lazy_result_t<F, size_t, size_t, T*>
+    load(const lib::ContextFreeLoadTable& table, std::istream& is, const F& lazy) {
+        auto datatype = lib::load_at<DataType>(table, "eltype");
+        if (datatype != datatype_v<T>) {
+            throw ANNEXCEPTION(
+                "Trying to load an uncompressed dataset with element types {} to a dataset "
+                "with element types {}.",
+                name(datatype),
+                name<datatype_v<T>>()
+            );
+        }
+
+        size_t num_vectors = lib::load_at<size_t>(table, "num_vectors");
+        size_t dims = lib::load_at<size_t>(table, "dims");
+
+        return io::load_dataset<T>(is, lazy, num_vectors, dims);
     }
 };
 
@@ -486,6 +506,31 @@ class SimpleData {
         );
     }
 
+    static SimpleData load(const lib::LoadTable& SVS_UNUSED(table))
+        requires(is_view)
+    {
+        throw ANNEXCEPTION("Trying to load a SimpleData view without an istream. This is "
+                           "not supported since "
+                           "views are compatible only with memory-mapped streams.");
+    }
+
+    static SimpleData load(const lib::ContextFreeLoadTable& table, std::istream& is)
+        requires(is_view)
+    {
+        if (!io::is_memory_stream(is)) {
+            throw ANNEXCEPTION(
+                "Trying to load a SimpleData view from a non-mmstream istream. This is not "
+                "supported since views are compatible only with memory-mapped streams."
+            );
+        }
+
+        return GenericSerializer::load<T>(
+            table, is, lib::Lazy([](size_t n_elements, size_t n_dimensions, T* ptr) {
+                return SimpleData(n_elements, n_dimensions, View<T>{ptr});
+            })
+        );
+    }
+
     ///
     /// @brief Try to automatically load the dataset.
     ///
@@ -596,6 +641,11 @@ bool operator==(const SimpleData<T1, E1, A1>& x, const SimpleData<T2, E2, A2>& y
         }
     }
     return true;
+}
+
+template <typename T, size_t Extent = Dynamic, typename Alloc = lib::Allocator<T>>
+size_t streaming_size(const svs::data::SimpleData<T, Extent, Alloc>& data) noexcept {
+    return data.capacity() * data.element_size();
 }
 
 /////

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -27,6 +27,7 @@
 #include "svs/lib/boundscheck.h"
 #include "svs/lib/datatype.h"
 #include "svs/lib/memory.h"
+#include "svs/lib/misc.h"
 #include "svs/lib/prefetch.h"
 #include "svs/lib/saveload.h"
 #include "svs/lib/threads.h"
@@ -673,6 +674,16 @@ template <typename Alloc> class Blocked {
 template <typename Alloc> inline constexpr bool is_blocked_v = false;
 template <typename Alloc> inline constexpr bool is_blocked_v<Blocked<Alloc>> = true;
 
+} // namespace data
+
+namespace lib::detail {
+// Allow rebinding of allocators through the Blocked wrapper.
+template <typename To, typename Alloc> struct AllocatorRebinder<To, data::Blocked<Alloc>> {
+    using type = data::Blocked<rebind_allocator_t<To, Alloc>>;
+};
+} // namespace lib::detail
+
+namespace data {
 ///
 /// @brief A specialization of ``SimpleData`` for large-scale dynamic datasets.
 ///

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -154,25 +154,6 @@ class GenericSerializer {
 
         return io::load_dataset(is, lazy, num_vectors, dims);
     }
-
-    template <typename T, lib::LazyInvocable<size_t, size_t, T*> F>
-    static lib::lazy_result_t<F, size_t, size_t, T*>
-    load(const lib::ContextFreeLoadTable& table, std::istream& is, const F& lazy) {
-        auto datatype = lib::load_at<DataType>(table, "eltype");
-        if (datatype != datatype_v<T>) {
-            throw ANNEXCEPTION(
-                "Trying to load an uncompressed dataset with element types {} to a dataset "
-                "with element types {}.",
-                name(datatype),
-                name<datatype_v<T>>()
-            );
-        }
-
-        size_t num_vectors = lib::load_at<size_t>(table, "num_vectors");
-        size_t dims = lib::load_at<size_t>(table, "dims");
-
-        return io::load_dataset<T>(is, lazy, num_vectors, dims);
-    }
 };
 
 struct Matcher {
@@ -517,6 +498,10 @@ class SimpleData {
     static SimpleData load(const lib::ContextFreeLoadTable& table, std::istream& is)
         requires(is_view)
     {
+        static_assert(
+            std::is_same_v<allocator_type, io::MemoryStreamAllocator<T>>,
+            "SimpleData views must use the MemoryStreamAllocator."
+        );
         if (!io::is_memory_stream(is)) {
             throw ANNEXCEPTION(
                 "Trying to load a SimpleData view from a non-mmstream istream. This is not "
@@ -524,9 +509,10 @@ class SimpleData {
             );
         }
 
+        allocator_type allocator(is);
         return GenericSerializer::load<T>(
-            table, is, lib::Lazy([](size_t n_elements, size_t n_dimensions, T* ptr) {
-                return SimpleData(n_elements, n_dimensions, View<T>{ptr});
+            table, is, lib::Lazy([&](size_t n_elements, size_t n_dimensions) {
+                return SimpleData(n_elements, n_dimensions, allocator);
             })
         );
     }
@@ -641,11 +627,6 @@ bool operator==(const SimpleData<T1, E1, A1>& x, const SimpleData<T2, E2, A2>& y
         }
     }
     return true;
-}
-
-template <typename T, size_t Extent = Dynamic, typename Alloc = lib::Allocator<T>>
-size_t streaming_size(const svs::data::SimpleData<T, Extent, Alloc>& data) noexcept {
-    return data.capacity() * data.element_size();
 }
 
 /////

--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -463,15 +463,18 @@ class SimpleData {
     /// svs::lib::load_from_disk<svs::data::SimpleData<T, Extent>>("directory");
     /// @endcode
     ///
-    static SimpleData
-    load(const lib::LoadTable& table, const allocator_type& allocator = {})
-        requires(!is_view)
-    {
+    static SimpleData load(const lib::LoadTable& table, const allocator_type& allocator) {
         return GenericSerializer::load<T>(
             table, lib::Lazy([&](size_t n_elements, size_t n_dimensions) {
                 return SimpleData(n_elements, n_dimensions, allocator);
             })
         );
+    }
+
+    static SimpleData load(const lib::LoadTable& table)
+        requires(!is_view)
+    {
+        return load(table, allocator_type{});
     }
 
     static SimpleData load(const lib::LoadTable& SVS_UNUSED(table))

--- a/include/svs/core/graph/graph.h
+++ b/include/svs/core/graph/graph.h
@@ -416,13 +416,12 @@ class SimpleGraph : public SimpleGraphBase<Idx, data::SimpleData<Idx, Dynamic, A
         return parent_type::load(table, lazy, allocator);
     }
 
+    template <typename... AllocArgs>
     static constexpr SimpleGraph load(
-        const lib::ContextFreeLoadTable& table,
-        std::istream& is,
-        const Alloc& allocator = {}
+        const lib::ContextFreeLoadTable& table, std::istream& is, AllocArgs&&... alloc_args
     ) {
         auto lazy = lib::Lazy([](data_type data) { return SimpleGraph(std::move(data)); });
-        return parent_type::load(table, lazy, is, allocator);
+        return parent_type::load(table, lazy, is, std::forward<AllocArgs>(alloc_args)...);
     }
 
     static constexpr SimpleGraph
@@ -434,8 +433,11 @@ class SimpleGraph : public SimpleGraphBase<Idx, data::SimpleData<Idx, Dynamic, A
         }
     }
 
-    static constexpr SimpleGraph load(std::istream& is, const Alloc& allocator = {}) {
-        return lib::load_from_stream<SimpleGraph>(is, allocator);
+    template <typename... AllocArgs>
+    static constexpr SimpleGraph load(std::istream& is, AllocArgs&&... alloc_args) {
+        return lib::load_from_stream<SimpleGraph>(
+            is, std::forward<AllocArgs>(alloc_args)...
+        );
     }
 };
 

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -524,6 +524,10 @@ struct MemoryStreamAllocator {
         }
     }
 
+    template <typename U>
+    MemoryStreamAllocator(const MemoryStreamAllocator<U, CharT, Traits>& other)
+        : stream_(other.stream()) {}
+
     [[nodiscard]] pointer allocate(size_type n) {
         T* current = current_ptr<T>(stream_);
         if (current == nullptr) {
@@ -541,6 +545,8 @@ struct MemoryStreamAllocator {
     void deallocate(pointer, size_type) noexcept {
         // No-op since we don't own the memory.
     }
+
+    std::basic_istream<CharT, Traits>& stream() const noexcept { return stream_; }
 
   private:
     std::basic_istream<CharT, Traits>& stream_;

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -515,9 +515,13 @@ struct MemoryStreamAllocator {
     using reference = T&;
     using const_reference = const T&;
 
-    MemoryStreamAllocator(std::basic_istream<CharT, Traits>& stream)
-        : stream_(stream) {
-        if (!is_memory_stream(stream_)) {
+    using stream_type = std::basic_istream<CharT, Traits>;
+
+    MemoryStreamAllocator() = default;
+
+    MemoryStreamAllocator(stream_type& stream)
+        : stream_(&stream) {
+        if (!is_memory_stream(*stream_)) {
             throw std::invalid_argument(
                 "MemoryStreamAllocator requires a memory-backed stream."
             );
@@ -526,17 +530,20 @@ struct MemoryStreamAllocator {
 
     template <typename U>
     MemoryStreamAllocator(const MemoryStreamAllocator<U, CharT, Traits>& other)
-        : stream_(other.stream()) {}
+        : stream_(&other.stream()) {}
 
     [[nodiscard]] pointer allocate(size_type n) {
-        T* current = current_ptr<T>(stream_);
+        if (stream_ == nullptr) {
+            throw std::runtime_error("MemoryStreamAllocator is not properly initialized.");
+        }
+        T* current = current_ptr<T>(*stream_);
         if (current == nullptr) {
             throw std::runtime_error("Failed to obtain current pointer from memory stream."
             );
         }
         pointer result = current;
-        stream_.seekg(n * sizeof(T), std::ios_base::cur);
-        if (!stream_) {
+        stream_->seekg(n * sizeof(T), std::ios_base::cur);
+        if (!*stream_) {
             throw std::runtime_error("Failed to advance memory stream after allocation.");
         }
         return result;
@@ -546,10 +553,10 @@ struct MemoryStreamAllocator {
         // No-op since we don't own the memory.
     }
 
-    std::basic_istream<CharT, Traits>& stream() const noexcept { return stream_; }
+    stream_type& stream() const noexcept { return *stream_; }
 
   private:
-    std::basic_istream<CharT, Traits>& stream_;
+    stream_type* stream_ = nullptr;
 };
 
 } // namespace io

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "svs/core/allocator.h"
 #include "svs/lib/array.h" // just for svs::is_view_type_v specialization
 
 #include <cerrno>
@@ -48,87 +49,53 @@ class basic_mmstreambuf : public std::basic_streambuf<CharT, Traits> {
     using pos_type = typename traits_type::pos_type;
     using off_type = typename traits_type::off_type;
 
-    basic_mmstreambuf() = default;
-
-    explicit basic_mmstreambuf(
-        const std::filesystem::path& path,
-        std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
-    ) {
-        open(path, mode);
+    explicit basic_mmstreambuf(MMapPtr<CharT> mapping)
+        : ptr_{std::move(mapping)} {
+        if (ptr_) {
+            auto base_ptr = static_cast<char_type*>(ptr_.base());
+            this->setg(base_ptr, ptr_.data(), base_ptr + ptr_.size());
+            this->setp(&empty_, &empty_); // disallow writing
+        } else {
+            this->setg(&empty_, &empty_, &empty_); // empty buffer
+            this->setp(&empty_, &empty_);          // disallow writing
+        }
     }
 
-    ~basic_mmstreambuf() override { close(); }
-
+    basic_mmstreambuf()
+        : basic_mmstreambuf(MMapPtr<CharT>{}) {}
     basic_mmstreambuf(const basic_mmstreambuf&) = delete;
     basic_mmstreambuf& operator=(const basic_mmstreambuf&) = delete;
+    basic_mmstreambuf(basic_mmstreambuf&&) = default;
+    basic_mmstreambuf& operator=(basic_mmstreambuf&&) = default;
 
-    basic_mmstreambuf(basic_mmstreambuf&& other) noexcept { move_from(std::move(other)); }
-
-    basic_mmstreambuf& operator=(basic_mmstreambuf&& other) noexcept {
-        if (this != &other) {
-            close();
-            move_from(std::move(other));
-        }
-        return *this;
-    }
-
-    void open(
+    basic_mmstreambuf* open(
         const std::filesystem::path& path,
         std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
     ) {
-        close();
-
-        fd_ = ::open(path.c_str(), to_file_mode(mode));
-        if (fd_ < 0) {
-            throw std::system_error(errno, std::generic_category(), "open() failed");
+        auto size = std::filesystem::file_size(path);
+        auto perm =
+            (mode & std::ios_base::out) ? MemoryMapper::ReadWrite : MemoryMapper::ReadOnly;
+        ptr_ =
+            MemoryMapper{perm, MemoryMapper::MustUseExisting}.mmap(path, lib::Bytes{size});
+        if (!ptr_) {
+            throw std::runtime_error("Failed to memory-map file: " + path.string());
         }
-
-        struct stat st {};
-        if (::fstat(fd_, &st) != 0) {
-            const int ec = errno;
-            close_fd_only();
-            throw std::system_error(ec, std::generic_category(), "fstat() failed");
-        }
-
-        if (st.st_size < 0) {
-            close_fd_only();
-            throw std::runtime_error("Invalid file size");
-        }
-
-        mapped_size_ = static_cast<std::size_t>(st.st_size);
-
-        if (mapped_size_ == 0) {
-            this->setg(&empty_, &empty_, &empty_);
-            return;
-        }
-
-        void* mapped =
-            ::mmap(nullptr, mapped_size_, to_mmap_prot(mode), MAP_SHARED, fd_, 0);
-        if (mapped == MAP_FAILED) {
-            const int ec = errno;
-            close_fd_only();
-            throw std::system_error(ec, std::generic_category(), "mmap() failed");
-        }
-
-        data_ = static_cast<char_type*>(mapped);
-        this->setg(data_, data_, data_ + mapped_size_);
+        auto base_ptr = static_cast<char_type*>(ptr_.base());
+        this->setg(base_ptr, base_ptr, base_ptr + ptr_.size());
+        this->setp(&empty_, &empty_); // disallow writing
+        return this;
     }
 
-    void close() noexcept {
-        this->setg(nullptr, nullptr, nullptr);
-
-        if (data_ != nullptr) {
-            ::munmap(static_cast<void*>(data_), mapped_size_);
-            data_ = nullptr;
-        }
-
-        mapped_size_ = 0;
-        close_fd_only();
+    basic_mmstreambuf* close() noexcept {
+        ptr_.unmap();
+        this->setg(&empty_, &empty_, &empty_); // empty buffer
+        this->setp(&empty_, &empty_);          // disallow writing
+        return this;
     }
 
-    [[nodiscard]] bool is_open() const noexcept { return fd_ >= 0; }
+    [[nodiscard]] bool is_open() const noexcept { return static_cast<bool>(ptr_); }
 
-    [[nodiscard]] std::size_t size() const noexcept { return mapped_size_; }
+    [[nodiscard]] std::size_t size() const noexcept { return ptr_.size(); }
 
   protected:
     int_type underflow() override {
@@ -175,67 +142,15 @@ class basic_mmstreambuf : public std::basic_streambuf<CharT, Traits> {
         return seekoff(static_cast<off_type>(sp), std::ios_base::beg, which);
     }
 
-  private:
-    void close_fd_only() noexcept {
-        if (fd_ >= 0) {
-            ::close(fd_);
-            fd_ = -1;
-        }
-    }
-
-    void move_from(basic_mmstreambuf&& other) noexcept {
-        fd_ = other.fd_;
-        other.fd_ = -1;
-
-        data_ = other.data_;
-        other.data_ = nullptr;
-
-        mapped_size_ = other.mapped_size_;
-        other.mapped_size_ = 0;
-
-        empty_ = other.empty_;
-
-        if (data_ != nullptr) {
-            this->setg(
-                data_,
-                data_ + (other.gptr() - other.eback()),
-                data_ + (other.egptr() - other.eback())
-            );
-        } else {
-            this->setg(&empty_, &empty_, &empty_);
-        }
-
-        other.setg(nullptr, nullptr, nullptr);
-    }
-
-    static int to_file_mode(std::ios_base::openmode mode) {
-        constexpr auto in_out = std::ios_base::in | std::ios_base::out;
-        int flags = 0;
-        if ((mode & in_out) == in_out) {
-            flags |= O_RDWR;
-        } else if (mode & std::ios_base::in) {
-            flags |= O_RDONLY;
-        } else if (mode & std::ios_base::out) {
-            flags |= O_WRONLY;
-        }
-        return flags;
-    }
-
-    static int to_mmap_prot(std::ios_base::openmode mode) {
-        int prot = 0;
-        if (mode & std::ios_base::in) {
-            prot |= PROT_READ;
-        }
-        if (mode & std::ios_base::out) {
-            prot |= PROT_WRITE;
-        }
-        return prot;
+    int_type overflow(int_type) override {
+        return Traits::eof(); // disallow writing
     }
 
   private:
-    int fd_ = -1;
-    char_type* data_ = nullptr;
-    std::size_t mapped_size_ = 0;
+    MMapPtr<CharT> ptr_;
+    // A dummy character to use as the put area for the streambuf when the mapping is empty
+    // or closed. This is necessary to ensure that the put area is always valid, even when
+    // the mapping is empty or closed.
     char_type empty_ = char_type{};
 };
 
@@ -249,14 +164,25 @@ class basic_mmstream : public std::basic_istream<CharT, Traits> {
         this->init(&buf_);
     }
 
-    explicit basic_mmstream(const std::filesystem::path& path)
+    explicit basic_mmstream(MMapPtr<CharT> mapping)
         : std::basic_istream<CharT, Traits>(nullptr)
-        , buf_(path) {
+        , buf_(std::move(mapping)) {
         this->init(&buf_);
     }
 
-    void open(const std::filesystem::path& path) {
-        buf_.open(path);
+    explicit basic_mmstream(
+        const std::filesystem::path& path,
+        std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
+    )
+        : basic_mmstream(MMapPtr<CharT>{}) {
+        open(path, mode);
+    }
+
+    void open(
+        const std::filesystem::path& path,
+        std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
+    ) {
+        buf_.open(path, mode);
         this->clear();
     }
 
@@ -340,7 +266,7 @@ struct StreambufAccessor : std::basic_streambuf<CharT, Traits> {
 template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
 [[nodiscard]] T* current_ptr(std::basic_istream<CharT, Traits>& stream) noexcept {
     static_assert(sizeof(CharT) == 1, "current_ptr requires a 1-byte character type.");
-    if (!stream.good() || !is_memory_stream(stream)) {
+    if (!is_memory_stream(stream)) {
         return nullptr;
     }
 

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -28,11 +28,6 @@
 #include <system_error>
 #include <type_traits>
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 namespace svs {
 namespace io {
 
@@ -72,16 +67,27 @@ class basic_mmstreambuf : public std::basic_streambuf<CharT, Traits> {
         const std::filesystem::path& path,
         std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
     ) {
-        auto size = std::filesystem::file_size(path);
+        std::error_code ec;
+        auto size = std::filesystem::file_size(path, ec);
+        if (ec) {
+            throw ANNEXCEPTION(
+                "Failed to get file size: {} with system error: {}",
+                path.string(),
+                ec.message()
+            );
+        }
+        if (size == 0) {
+            throw ANNEXCEPTION("Cannot memory-map empty file: {}", path.string());
+        }
         auto perm =
             (mode & std::ios_base::out) ? MemoryMapper::ReadWrite : MemoryMapper::ReadOnly;
         ptr_ =
             MemoryMapper{perm, MemoryMapper::MustUseExisting}.mmap(path, lib::Bytes{size});
         if (!ptr_) {
-            throw std::runtime_error("Failed to memory-map file: " + path.string());
+            throw ANNEXCEPTION("Failed to memory-map file: {}", path.string());
         }
         auto base_ptr = static_cast<char_type*>(ptr_.base());
-        this->setg(base_ptr, base_ptr, base_ptr + ptr_.size());
+        this->setg(base_ptr, ptr_.data(), base_ptr + ptr_.size());
         this->setp(&empty_, &empty_); // disallow writing
         return this;
     }

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <filesystem>
+#include <istream>
+#include <sstream>
+#include <stdexcept>
+#include <streambuf>
+#include <system_error>
+#include <type_traits>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace svs::io {
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_mmstreambuf : public std::basic_streambuf<CharT, Traits> {
+    static_assert(
+        sizeof(CharT) == 1, "basic_mmstreambuf requires a 1-byte character type."
+    );
+
+  public:
+    using char_type = CharT;
+    using traits_type = Traits;
+    using int_type = typename traits_type::int_type;
+    using pos_type = typename traits_type::pos_type;
+    using off_type = typename traits_type::off_type;
+
+    basic_mmstreambuf() = default;
+
+    explicit basic_mmstreambuf(
+        const std::filesystem::path& path,
+        std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
+    ) {
+        open(path, mode);
+    }
+
+    ~basic_mmstreambuf() override { close(); }
+
+    basic_mmstreambuf(const basic_mmstreambuf&) = delete;
+    basic_mmstreambuf& operator=(const basic_mmstreambuf&) = delete;
+
+    basic_mmstreambuf(basic_mmstreambuf&& other) noexcept { move_from(std::move(other)); }
+
+    basic_mmstreambuf& operator=(basic_mmstreambuf&& other) noexcept {
+        if (this != &other) {
+            close();
+            move_from(std::move(other));
+        }
+        return *this;
+    }
+
+    void open(
+        const std::filesystem::path& path,
+        std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out
+    ) {
+        close();
+
+        fd_ = ::open(path.c_str(), to_file_mode(mode));
+        if (fd_ < 0) {
+            throw std::system_error(errno, std::generic_category(), "open() failed");
+        }
+
+        struct stat st {};
+        if (::fstat(fd_, &st) != 0) {
+            const int ec = errno;
+            close_fd_only();
+            throw std::system_error(ec, std::generic_category(), "fstat() failed");
+        }
+
+        if (st.st_size < 0) {
+            close_fd_only();
+            throw std::runtime_error("Invalid file size");
+        }
+
+        mapped_size_ = static_cast<std::size_t>(st.st_size);
+
+        if (mapped_size_ == 0) {
+            this->setg(&empty_, &empty_, &empty_);
+            return;
+        }
+
+        void* mapped =
+            ::mmap(nullptr, mapped_size_, to_mmap_prot(mode), MAP_SHARED, fd_, 0);
+        if (mapped == MAP_FAILED) {
+            const int ec = errno;
+            close_fd_only();
+            throw std::system_error(ec, std::generic_category(), "mmap() failed");
+        }
+
+        data_ = static_cast<char_type*>(mapped);
+        this->setg(data_, data_, data_ + mapped_size_);
+    }
+
+    void close() noexcept {
+        this->setg(nullptr, nullptr, nullptr);
+
+        if (data_ != nullptr) {
+            ::munmap(static_cast<void*>(data_), mapped_size_);
+            data_ = nullptr;
+        }
+
+        mapped_size_ = 0;
+        close_fd_only();
+    }
+
+    [[nodiscard]] bool is_open() const noexcept { return fd_ >= 0; }
+
+    [[nodiscard]] std::size_t size() const noexcept { return mapped_size_; }
+
+  protected:
+    int_type underflow() override {
+        if (this->gptr() == this->egptr()) {
+            return traits_type::eof();
+        }
+        return traits_type::to_int_type(*this->gptr());
+    }
+
+    pos_type seekoff(
+        off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which
+    ) override {
+        if (!(which & std::ios_base::in)) {
+            return pos_type(off_type(-1));
+        }
+
+        const off_type current = static_cast<off_type>(this->gptr() - this->eback());
+        const off_type end = static_cast<off_type>(this->egptr() - this->eback());
+
+        off_type target = 0;
+        switch (dir) {
+            case std::ios_base::beg:
+                target = off;
+                break;
+            case std::ios_base::cur:
+                target = current + off;
+                break;
+            case std::ios_base::end:
+                target = end + off;
+                break;
+            default:
+                return pos_type(off_type(-1));
+        }
+
+        if (target < 0 || target > end) {
+            return pos_type(off_type(-1));
+        }
+
+        this->setg(this->eback(), this->eback() + target, this->egptr());
+        return pos_type(target);
+    }
+
+    pos_type seekpos(pos_type sp, std::ios_base::openmode which) override {
+        return seekoff(static_cast<off_type>(sp), std::ios_base::beg, which);
+    }
+
+  private:
+    void close_fd_only() noexcept {
+        if (fd_ >= 0) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+    }
+
+    void move_from(basic_mmstreambuf&& other) noexcept {
+        fd_ = other.fd_;
+        other.fd_ = -1;
+
+        data_ = other.data_;
+        other.data_ = nullptr;
+
+        mapped_size_ = other.mapped_size_;
+        other.mapped_size_ = 0;
+
+        empty_ = other.empty_;
+
+        if (data_ != nullptr) {
+            this->setg(
+                data_,
+                data_ + (other.gptr() - other.eback()),
+                data_ + (other.egptr() - other.eback())
+            );
+        } else {
+            this->setg(&empty_, &empty_, &empty_);
+        }
+
+        other.setg(nullptr, nullptr, nullptr);
+    }
+
+    static int to_file_mode(std::ios_base::openmode mode) {
+        constexpr auto in_out = std::ios_base::in | std::ios_base::out;
+        int flags = 0;
+        if ((mode & in_out) == in_out) {
+            flags |= O_RDWR;
+        } else if (mode & std::ios_base::in) {
+            flags |= O_RDONLY;
+        } else if (mode & std::ios_base::out) {
+            flags |= O_WRONLY;
+        }
+        return flags;
+    }
+
+    static int to_mmap_prot(std::ios_base::openmode mode) {
+        int prot = 0;
+        if (mode & std::ios_base::in) {
+            prot |= PROT_READ;
+        }
+        if (mode & std::ios_base::out) {
+            prot |= PROT_WRITE;
+        }
+        return prot;
+    }
+
+  private:
+    int fd_ = -1;
+    char_type* data_ = nullptr;
+    std::size_t mapped_size_ = 0;
+    char_type empty_ = char_type{};
+};
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_mmstream : public std::basic_istream<CharT, Traits> {
+  public:
+    using streambuf_type = basic_mmstreambuf<CharT, Traits>;
+
+    basic_mmstream()
+        : std::basic_istream<CharT, Traits>(nullptr) {
+        this->init(&buf_);
+    }
+
+    explicit basic_mmstream(const std::filesystem::path& path)
+        : std::basic_istream<CharT, Traits>(nullptr)
+        , buf_(path) {
+        this->init(&buf_);
+    }
+
+    void open(const std::filesystem::path& path) {
+        buf_.open(path);
+        this->clear();
+    }
+
+    void close() noexcept {
+        buf_.close();
+        this->setstate(std::ios_base::eofbit);
+    }
+
+    [[nodiscard]] bool is_open() const noexcept { return buf_.is_open(); }
+
+    [[nodiscard]] std::size_t size() const noexcept { return buf_.size(); }
+
+    [[nodiscard]] streambuf_type* rdbuf() noexcept { return &buf_; }
+
+  private:
+    streambuf_type buf_;
+};
+
+using mmstreambuf = basic_mmstreambuf<char>;
+using mmstream = basic_mmstream<char>;
+
+/// Returns true if @p stream is backed entirely by an in-memory buffer.
+///
+/// Specifically, returns true when the stream's streambuf is either:
+///   - a @c basic_mmstreambuf (memory-mapped file), or
+///   - a @c std::basic_stringbuf (std::istringstream / std::stringstream).
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+[[nodiscard]] bool is_memory_stream(std::basic_istream<CharT, Traits>& stream) noexcept {
+    auto* buf = stream.rdbuf();
+    if (buf == nullptr) {
+        return false;
+    }
+    if (dynamic_cast<basic_mmstreambuf<CharT, Traits>*>(buf) != nullptr) {
+        return true;
+    }
+    if (dynamic_cast<std::basic_stringbuf<CharT, Traits>*>(buf) != nullptr) {
+        return true;
+    }
+    return false;
+}
+
+namespace detail {
+
+// A minimal accessor that promotes the protected gptr() method of
+// std::basic_streambuf to public visibility.  It adds no data members and no
+// virtual functions, so the static_cast below is layout-safe (gptr() reads only
+// base-class internal pointers).
+template <typename CharT, typename Traits>
+struct StreambufAccessor : std::basic_streambuf<CharT, Traits> {
+    static CharT* get(std::basic_streambuf<CharT, Traits>* buf) noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<StreambufAccessor*>(buf)->gptr();
+    }
+
+    static CharT* begin(std::basic_streambuf<CharT, Traits>* buf) noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<StreambufAccessor*>(buf)->eback();
+    }
+
+    static CharT* end(std::basic_streambuf<CharT, Traits>* buf) noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<StreambufAccessor*>(buf)->egptr();
+    }
+};
+
+} // namespace detail
+
+/// Returns a typed pointer to the current read position of an in-memory stream.
+///
+/// Works for:
+///   - @c basic_mmstreambuf-backed streams (memory-mapped files via @c basic_mmstream)
+///   - @c std::basic_stringbuf-backed streams (@c std::istringstream / @c
+///   std::stringstream)
+///
+/// @tparam T        Element type to interpret the raw bytes at the current position as.
+/// @tparam CharT    Character type of the stream (must be 1-byte wide).
+/// @tparam Traits   Character traits of the stream.
+/// @param  stream   The input stream to query.
+/// @returns A pointer of type @c T* to the current read position,
+///          or @c nullptr if the stream is not in-memory or has no streambuf.
+template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
+[[nodiscard]] T* current_ptr(std::basic_istream<CharT, Traits>& stream) noexcept {
+    static_assert(sizeof(CharT) == 1, "current_ptr requires a 1-byte character type.");
+    if (!is_memory_stream(stream)) {
+        return nullptr;
+    }
+
+    auto* buf = stream.rdbuf();
+    auto begin = detail::StreambufAccessor<CharT, Traits>::begin(buf);
+    auto end = detail::StreambufAccessor<CharT, Traits>::end(buf);
+    if (begin == end) {
+        return nullptr;
+    }
+    auto raw = detail::StreambufAccessor<CharT, Traits>::get(buf);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<T*>(raw);
+}
+
+/// Returns a typed pointer to the beginning of the read position of an in-memory stream.
+///
+/// Works for:
+///   - @c basic_mmstreambuf-backed streams (memory-mapped files via @c basic_mmstream)
+///   - @c std::basic_stringbuf-backed streams (@c std::istringstream / @c
+///   std::stringstream)
+///
+/// @tparam T        Element type to interpret the raw bytes at the current position as.
+/// @tparam CharT    Character type of the stream (must be 1-byte wide).
+/// @tparam Traits   Character traits of the stream.
+/// @param  stream   The input stream to query.
+/// @returns A pointer of type @c T* to the beginning of the read position,
+///          or @c nullptr if the stream is not in-memory or has no streambuf.
+template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
+[[nodiscard]] T* begin_ptr(std::basic_istream<CharT, Traits>& stream) noexcept {
+    static_assert(sizeof(CharT) == 1, "begin_ptr requires a 1-byte character type.");
+    if (!is_memory_stream(stream)) {
+        return nullptr;
+    }
+
+    auto* buf = stream.rdbuf();
+    auto begin = detail::StreambufAccessor<CharT, Traits>::begin(buf);
+    auto end = detail::StreambufAccessor<CharT, Traits>::end(buf);
+    if (begin == end) {
+        return nullptr;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<T*>(begin);
+}
+
+/// Returns a typed pointer to the end of the read position of an in-memory stream.
+///
+/// Works for:
+///   - @c basic_mmstreambuf-backed streams (memory-mapped files via @c basic_mmstream)
+///   - @c std::basic_stringbuf-backed streams (@c std::istringstream / @c
+///   std::stringstream)
+///
+/// @tparam T        Element type to interpret the raw bytes at the current position as.
+/// @tparam CharT    Character type of the stream (must be 1-byte wide).
+/// @tparam Traits   Character traits of the stream.
+/// @param  stream   The input stream to query.
+/// @returns A pointer of type @c T* to the end of the read position,
+///          or @c nullptr if the stream is not in-memory or has no streambuf.
+template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
+[[nodiscard]] T* end_ptr(std::basic_istream<CharT, Traits>& stream) noexcept {
+    static_assert(sizeof(CharT) == 1, "end_ptr requires a 1-byte character type.");
+    if (!is_memory_stream(stream)) {
+        return nullptr;
+    }
+
+    auto* buf = stream.rdbuf();
+    auto begin = detail::StreambufAccessor<CharT, Traits>::begin(buf);
+    auto end = detail::StreambufAccessor<CharT, Traits>::end(buf);
+    if (begin == end) {
+        return nullptr;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<T*>(end);
+}
+
+} // namespace svs::io

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -430,6 +430,15 @@ template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
     }
     auto raw = detail::StreambufAccessor<CharT, Traits>::get(buf);
 
+    // Return nullptr if the current position is misaligned for the requested type T, to
+    // avoid undefined behavior on dereference.
+    if (reinterpret_cast<std::uintptr_t>(raw) % alignof(T) != 0) {
+        assert(
+            false && "current_ptr: current position is misaligned for the requested type T"
+        );
+        return nullptr;
+    }
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<T*>(raw);
 }
@@ -542,7 +551,11 @@ struct MemoryStreamAllocator {
             );
         }
         pointer result = current;
-        stream_->seekg(n * sizeof(T), std::ios_base::cur);
+
+        // check for overflow:
+        auto off = lib::narrow<typename stream_type::off_type>(n * sizeof(T));
+
+        stream_->seekg(off, std::ios_base::cur);
         if (!*stream_) {
             throw std::runtime_error("Failed to advance memory stream after allocation.");
         }

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "svs/lib/array.h" // just for svs::is_view_type_v specialization
+
 #include <cerrno>
 #include <cstddef>
 #include <filesystem>
@@ -30,7 +32,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-namespace svs::io {
+namespace svs {
+namespace io {
 
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 class basic_mmstreambuf : public std::basic_streambuf<CharT, Traits> {
@@ -337,7 +340,7 @@ struct StreambufAccessor : std::basic_streambuf<CharT, Traits> {
 template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
 [[nodiscard]] T* current_ptr(std::basic_istream<CharT, Traits>& stream) noexcept {
     static_assert(sizeof(CharT) == 1, "current_ptr requires a 1-byte character type.");
-    if (!is_memory_stream(stream)) {
+    if (!stream.good() || !is_memory_stream(stream)) {
         return nullptr;
     }
 
@@ -415,4 +418,59 @@ template <typename T, typename CharT, typename Traits = std::char_traits<CharT>>
     return reinterpret_cast<T*>(end);
 }
 
-} // namespace svs::io
+/// @brief Memory-stream allocator that allocates memory from in-memory streams.
+///
+/// This is used to construct SVS data structures directly on memory-mapped files or
+/// in-memory buffers, without needing to copy data out of the stream into separately
+/// allocated memory.
+///
+/// The allocator does not take ownership of the memory; the caller is responsible for
+/// ensuring the memory remains valid for the lifetime of any pointers returned by this
+/// allocator.
+template <typename T, typename CharT = char, typename Traits = std::char_traits<CharT>>
+struct MemoryStreamAllocator {
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+
+    MemoryStreamAllocator(std::basic_istream<CharT, Traits>& stream)
+        : stream_(stream) {
+        if (!is_memory_stream(stream_)) {
+            throw std::invalid_argument(
+                "MemoryStreamAllocator requires a memory-backed stream."
+            );
+        }
+    }
+
+    [[nodiscard]] pointer allocate(size_type n) {
+        T* current = current_ptr<T>(stream_);
+        if (current == nullptr) {
+            throw std::runtime_error("Failed to obtain current pointer from memory stream."
+            );
+        }
+        pointer result = current;
+        stream_.seekg(n * sizeof(T), std::ios_base::cur);
+        if (!stream_) {
+            throw std::runtime_error("Failed to advance memory stream after allocation.");
+        }
+        return result;
+    }
+
+    void deallocate(pointer, size_type) noexcept {
+        // No-op since we don't own the memory.
+    }
+
+  private:
+    std::basic_istream<CharT, Traits>& stream_;
+};
+
+} // namespace io
+
+template <typename T>
+inline constexpr bool is_view_type_v<io::MemoryStreamAllocator<T>> = true;
+
+} // namespace svs

--- a/include/svs/core/io/memstream.h
+++ b/include/svs/core/io/memstream.h
@@ -22,11 +22,20 @@
 #include <cstddef>
 #include <filesystem>
 #include <istream>
+#include <span>
 #include <sstream>
 #include <stdexcept>
 #include <streambuf>
 #include <system_error>
 #include <type_traits>
+#include <version>
+
+#if defined(__cpp_lib_spanstream) && __cpp_lib_spanstream >= 202106L
+#include <spanstream>
+#define SVS_HAS_STD_SPANSTREAM 1
+#else
+#define SVS_HAS_STD_SPANSTREAM 0
+#endif
 
 namespace svs {
 namespace io {
@@ -210,10 +219,144 @@ class basic_mmstream : public std::basic_istream<CharT, Traits> {
 using mmstreambuf = basic_mmstreambuf<char>;
 using mmstream = basic_mmstream<char>;
 
+#if SVS_HAS_STD_SPANSTREAM
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+using basic_spanbuf = std::basic_spanbuf<CharT, Traits>;
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+using basic_ispanstream = std::basic_ispanstream<CharT, Traits>;
+
+#else
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_spanbuf : public std::basic_streambuf<CharT, Traits> {
+    static_assert(sizeof(CharT) == 1, "basic_spanbuf requires a 1-byte character type.");
+
+  public:
+    using char_type = CharT;
+    using traits_type = Traits;
+    using int_type = typename traits_type::int_type;
+    using pos_type = typename traits_type::pos_type;
+    using off_type = typename traits_type::off_type;
+    using span_type = std::span<CharT>;
+
+    basic_spanbuf()
+        : basic_spanbuf(span_type{}) {}
+
+    explicit basic_spanbuf(span_type s) { span(s); }
+
+    /// Returns the underlying span.
+    [[nodiscard]] span_type span() const noexcept { return data_; }
+
+    /// Updates the underlying span and resets the read position to the beginning.
+    void span(span_type s) noexcept {
+        data_ = s;
+        if (data_.empty()) {
+            this->setg(&empty_, &empty_, &empty_);
+        } else {
+            auto* begin = data_.data();
+            this->setg(begin, begin, begin + data_.size());
+        }
+        this->setp(&empty_, &empty_); // disallow writing
+    }
+
+  protected:
+    int_type overflow(int_type) override {
+        return traits_type::eof(); // disallow writing
+    }
+
+    std::basic_streambuf<CharT, Traits>* setbuf(char_type* s, std::streamsize n) override {
+        span(span_type{s, static_cast<std::size_t>(n)});
+        return this;
+    }
+
+    pos_type seekoff(
+        off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which
+    ) override {
+        if (!(which & std::ios_base::in)) {
+            return pos_type(off_type(-1));
+        }
+
+        const off_type current = static_cast<off_type>(this->gptr() - this->eback());
+        const off_type end = static_cast<off_type>(this->egptr() - this->eback());
+
+        off_type target = 0;
+        switch (dir) {
+            case std::ios_base::beg:
+                target = off;
+                break;
+            case std::ios_base::cur:
+                target = current + off;
+                break;
+            case std::ios_base::end:
+                target = end + off;
+                break;
+            default:
+                return pos_type(off_type(-1));
+        }
+
+        if (target < 0 || target > end) {
+            return pos_type(off_type(-1));
+        }
+
+        this->setg(this->eback(), this->eback() + target, this->egptr());
+        return pos_type(target);
+    }
+
+    pos_type seekpos(pos_type sp, std::ios_base::openmode which) override {
+        return seekoff(static_cast<off_type>(sp), std::ios_base::beg, which);
+    }
+
+  private:
+    span_type data_;
+    char_type empty_ = char_type{};
+};
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_ispanstream : public std::basic_istream<CharT, Traits> {
+  public:
+    using char_type = CharT;
+    using traits_type = Traits;
+    using int_type = typename traits_type::int_type;
+    using pos_type = typename traits_type::pos_type;
+    using off_type = typename traits_type::off_type;
+    using streambuf_type = basic_spanbuf<CharT, Traits>;
+    using span_type = typename streambuf_type::span_type;
+
+    basic_ispanstream()
+        : std::basic_istream<CharT, Traits>(nullptr) {
+        this->init(&buf_);
+    }
+
+    explicit basic_ispanstream(span_type span)
+        : std::basic_istream<CharT, Traits>(nullptr)
+        , buf_(span) {
+        this->init(&buf_);
+    }
+
+    span_type span() const noexcept { return buf_.span(); }
+    void span(span_type s) noexcept {
+        buf_.span(s);
+        this->clear();
+    }
+
+    [[nodiscard]] streambuf_type* rdbuf() noexcept { return &buf_; }
+
+  private:
+    streambuf_type buf_;
+};
+
+#endif
+
+using spanbuf = basic_spanbuf<char>;
+using ispanstream = basic_ispanstream<char>;
+
 /// Returns true if @p stream is backed entirely by an in-memory buffer.
 ///
 /// Specifically, returns true when the stream's streambuf is either:
 ///   - a @c basic_mmstreambuf (memory-mapped file), or
+///   - a @c basic_spanbuf (non-owning in-memory span), or
 ///   - a @c std::basic_stringbuf (std::istringstream / std::stringstream).
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 [[nodiscard]] bool is_memory_stream(std::basic_istream<CharT, Traits>& stream) noexcept {
@@ -222,6 +365,9 @@ template <typename CharT, typename Traits = std::char_traits<CharT>>
         return false;
     }
     if (dynamic_cast<basic_mmstreambuf<CharT, Traits>*>(buf) != nullptr) {
+        return true;
+    }
+    if (dynamic_cast<basic_spanbuf<CharT, Traits>*>(buf) != nullptr) {
         return true;
     }
     if (dynamic_cast<std::basic_stringbuf<CharT, Traits>*>(buf) != nullptr) {

--- a/include/svs/lib/array.h
+++ b/include/svs/lib/array.h
@@ -156,6 +156,9 @@ template <typename T> struct View {
 template <typename T> inline constexpr bool is_view_type_v = false;
 template <typename T> inline constexpr bool is_view_type_v<View<T>> = true;
 
+template <typename T>
+concept ViewAllocator = is_view_type_v<T>;
+
 namespace array_impl {
 
 // Shared implementations across various DenseArray specializations.
@@ -507,7 +510,7 @@ template <typename T, typename Dims, typename Alloc = lib::Allocator<T>> class D
     [[no_unique_address]] Alloc allocator_;
 };
 
-template <typename T, typename Dims> class DenseArray<T, Dims, View<T>> {
+template <typename T, typename Dims, ViewAllocator Alloc> class DenseArray<T, Dims, Alloc> {
   private:
     // N.B.: This is an important assumption for many algorithms of this type.
     // Don't remove this requirement without careful consideration.
@@ -517,6 +520,7 @@ template <typename T, typename Dims> class DenseArray<T, Dims, View<T>> {
     static constexpr bool is_const = std::is_const_v<T>;
 
     ///// Allocator Aware
+    using allocator_type = Alloc;
     using pointer = T*;
     using const_pointer = const T*;
 
@@ -650,8 +654,14 @@ template <typename T, typename Dims> class DenseArray<T, Dims, View<T>> {
         : pointer_{ptr}
         , dims_{std::move(dims)} {}
 
-    explicit DenseArray(Dims dims, View<T> view)
-        : DenseArray{std::move(dims), view.ptr} {}
+    explicit DenseArray(Dims dims, Alloc allocator)
+        : DenseArray{std::move(dims), nullptr} {
+        if constexpr (std::is_same_v<Alloc, View<T>>) {
+            pointer_ = allocator.ptr;
+        } else {
+            pointer_ = std::allocator_traits<allocator_type>::allocate(allocator, size());
+        }
+    }
 
     // Iterator
     pointer begin()

--- a/include/svs/lib/array.h
+++ b/include/svs/lib/array.h
@@ -537,6 +537,9 @@ template <typename T, typename Dims, ViewAllocator Alloc> class DenseArray<T, Di
     using const_span = std::span<const T, detail::getextent<Dims>>;
     using span = std::span<T, detail::getextent<Dims>>;
 
+    // Get the underlying allocator.
+    const allocator_type& get_allocator() const { return allocator_; }
+
     /// @brief Return the extent of the span returned for `slice`.
     static constexpr size_t extent() { return array_impl::extent<Dims>(); }
 
@@ -651,15 +654,19 @@ template <typename T, typename Dims, ViewAllocator Alloc> class DenseArray<T, Di
     /////
 
     explicit DenseArray(Dims dims, pointer ptr)
+        requires(std::is_same_v<Alloc, View<T>>)
         : pointer_{ptr}
-        , dims_{std::move(dims)} {}
+        , dims_{std::move(dims)}
+        , allocator_{ptr} {}
 
     explicit DenseArray(Dims dims, Alloc allocator)
-        : DenseArray{std::move(dims), nullptr} {
+        : pointer_{nullptr}
+        , dims_{std::move(dims)}
+        , allocator_{allocator} {
         if constexpr (std::is_same_v<Alloc, View<T>>) {
-            pointer_ = allocator.ptr;
+            pointer_ = allocator_.ptr;
         } else {
-            pointer_ = std::allocator_traits<allocator_type>::allocate(allocator, size());
+            pointer_ = std::allocator_traits<allocator_type>::allocate(allocator_, size());
         }
     }
 
@@ -692,6 +699,7 @@ template <typename T, typename Dims, ViewAllocator Alloc> class DenseArray<T, Di
   private:
     pointer pointer_{nullptr};
     [[no_unique_address]] Dims dims_{};
+    [[no_unique_address]] Alloc allocator_;
 };
 
 template <size_t I, typename T, typename Dims, typename Alloc>

--- a/include/svs/lib/misc.h
+++ b/include/svs/lib/misc.h
@@ -40,8 +40,13 @@ namespace svs::lib {
 struct ZeroInitializer {};
 
 /// @brief Get the full type of the allocator `Alloc` rebound to a value to `To`.
+namespace detail {
+template <typename To, typename Alloc> struct AllocatorRebinder {
+    using type = typename std::allocator_traits<Alloc>::template rebind_alloc<To>;
+};
+} // namespace detail
 template <typename To, typename Alloc>
-using rebind_allocator_t = typename std::allocator_traits<Alloc>::template rebind_alloc<To>;
+using rebind_allocator_t = typename detail::AllocatorRebinder<To, Alloc>::type;
 
 /// @brief Rebind an allocator to a new value type.
 template <typename To, typename Alloc>

--- a/include/svs/lib/stream.h
+++ b/include/svs/lib/stream.h
@@ -62,6 +62,22 @@ struct StreamArchiver : Archiver<StreamArchiver> {
         // but Apple's Clang 15 doesn't support std::stringbuf::view()
         lib::StreamArchiver::size_type tablesize = detail::get_buffer_size(ss);
 
+        // Get the current position in the stream and compute the padding characters needed
+        // to align the (table + tablesize values) to a cache line boundary.
+        auto pos = os.tellp();
+        // check if position is valid before using it. If it's not valid, we can assume that
+        // the stream is at the beginning and thus doesn't need padding.
+        pos = std::max(pos, decltype(pos)(0));
+
+        auto padding = (lib::StreamArchiver::CACHELINE_BYTES -
+                        (static_cast<size_t>(pos) + sizeof(tablesize) + tablesize) %
+                            lib::StreamArchiver::CACHELINE_BYTES) %
+                       lib::StreamArchiver::CACHELINE_BYTES;
+
+        ss << std::string(padding, ' ');
+        // recompute tablesize after adding padding.
+        tablesize = detail::get_buffer_size(ss);
+
         lib::StreamArchiver::write_size(os, tablesize);
         os << ss.rdbuf();
         if (!os) {

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -469,7 +469,12 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
         auto deserializer = svs::lib::detail::Deserializer::build(stream);
         if (deserializer.is_native()) {
             auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
-            using GraphType = svs::GraphLoader<>::return_type;
+
+            using GraphType = std::conditional_t<
+                is_view_type_v<typename Data::allocator_type>,
+                graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>,
+                GraphLoader<>::return_type>;
+
             if constexpr (std::is_same_v<Distance, DistanceType>) {
                 auto dispatcher = DistanceDispatcher(distance);
                 return dispatcher([&](auto distance_function) {

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -472,7 +472,9 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
 
             using GraphType = std::conditional_t<
                 is_view_type_v<typename Data::allocator_type>,
-                graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>,
+                graphs::SimpleGraph<
+                    uint32_t,
+                    lib::rebind_allocator_t<uint32_t, typename Data::allocator_type>>,
                 GraphLoader<>::return_type>;
 
             if constexpr (std::is_same_v<Distance, DistanceType>) {

--- a/include/svs/quantization/scalar/scalar.h
+++ b/include/svs/quantization/scalar/scalar.h
@@ -198,7 +198,7 @@ namespace detail {
 
 struct MinMaxAccumulator {
     float min = std::numeric_limits<float>::max();
-    float max = std::numeric_limits<float>::min();
+    float max = std::numeric_limits<float>::lowest();
 
     void accumulate(float val) {
         min = std::min(min, val);
@@ -369,8 +369,8 @@ class SQDataset {
     using allocator_type = Alloc;
     using element_type = T;
     using data_type = data::SimpleData<element_type, Extent, allocator_type>;
-    using const_value_type = std::span<const element_type, Extent>;
-    using value_type = const_value_type;
+    using const_value_type = typename data_type::const_value_type;
+    using value_type = typename data_type::value_type;
 
     // Data wrapped in the library allocator.
     using lib_alloc_data_type = SQDataset<T, Extent, lib::Allocator<T>>;
@@ -399,6 +399,7 @@ class SQDataset {
     float get_bias() const { return bias_; }
 
     const_value_type get_datum(size_t i) const { return data_.get_datum(i); }
+    value_type get_datum(size_t i) { return data_.get_datum(i); }
 
     std::vector<float> decompress_datum(size_t i) const {
         auto datum = get_datum(i);
@@ -510,22 +511,20 @@ class SQDataset {
     void save(std::ostream& os) const { data_.save(os); }
 
     /// @brief Load dataset from a file.
-    static SQDataset
-    load(const lib::LoadTable& table, const allocator_type& allocator = {}) {
+    template <typename... Args>
+    static SQDataset load(const lib::LoadTable& table, Args&&... args) {
         return SQDataset<element_type, extent, allocator_type>{
-            SVS_LOAD_MEMBER_AT_(table, data, allocator),
+            SVS_LOAD_MEMBER_AT_(table, data, std::forward<Args>(args)...),
             lib::load_at<float>(table, "scale"),
             lib::load_at<float>(table, "bias")};
     }
 
     /// @brief Load dataset from a stream.
-    static SQDataset load(
-        const lib::ContextFreeLoadTable& table,
-        std::istream& is,
-        const allocator_type& allocator = {}
-    ) {
+    template <typename... Args>
+    static SQDataset
+    load(const lib::ContextFreeLoadTable& table, std::istream& is, Args&&... args) {
         return SQDataset<element_type, extent, allocator_type>{
-            SVS_LOAD_MEMBER_AT_(table, data, is, allocator),
+            SVS_LOAD_MEMBER_AT_(table, data, is, std::forward<Args>(args)...),
             lib::load_at<float>(table, "scale"),
             lib::load_at<float>(table, "bias")};
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/svs/core/io/vecs.cpp
     ${TEST_DIR}/svs/core/io/binary.cpp
     ${TEST_DIR}/svs/core/io/native.cpp
+    ${TEST_DIR}/svs/core/io/memstream.cpp
     ${TEST_DIR}/svs/core/io.cpp
     ${TEST_DIR}/svs/core/loading.cpp
     ${TEST_DIR}/svs/core/logging.cpp

--- a/tests/svs/core/data/simple.cpp
+++ b/tests/svs/core/data/simple.cpp
@@ -234,7 +234,10 @@ CATCH_TEST_CASE("Testing Simple Data", "[core][data]") {
         CATCH_REQUIRE(expected_ptr != nullptr);
 
         // Load the view — data_ must point into the stringstream's internal buffer.
-        auto view = svs::data::SimpleDataView<float>::load(table, ss);
+        auto view = svs::data::
+            SimpleData<float, svs::Dynamic, svs::io::MemoryStreamAllocator<float>>::load(
+                table, ss
+            );
         CATCH_REQUIRE(view.data() == expected_ptr);
         CATCH_REQUIRE(view.size() == src.size());
         CATCH_REQUIRE(view.dimensions() == src.dimensions());
@@ -252,7 +255,10 @@ CATCH_TEST_CASE("Testing Simple Data", "[core][data]") {
         NonMemStreamBuf buf;
         std::istream non_mem_stream(&buf);
         CATCH_REQUIRE_THROWS_AS(
-            (svs::data::SimpleDataView<float>::load(table, non_mem_stream)),
+            (svs::data::SimpleData<
+                float,
+                svs::Dynamic,
+                svs::io::MemoryStreamAllocator<float>>::load(table, non_mem_stream)),
             svs::ANNException
         );
     }

--- a/tests/svs/core/data/simple.cpp
+++ b/tests/svs/core/data/simple.cpp
@@ -23,6 +23,7 @@
 
 // stdlib
 #include <span>
+#include <sstream>
 #include <type_traits>
 
 // catch2
@@ -212,6 +213,47 @@ CATCH_TEST_CASE("Testing Simple Data", "[core][data]") {
         // Incorrect type.
         CATCH_REQUIRE_THROWS_AS(
             svs::data::ConstSimpleDataView<double>(y), svs::ANNException
+        );
+    }
+
+    CATCH_SECTION("Load SimpleDataView from stringstream") {
+        auto src = svs::data::SimpleData<float>(5, 4);
+        svs_test::data::set_sequential(src);
+
+        // Save binary data to a stringstream and seek to the beginning for reading.
+        auto ss = std::stringstream{};
+        src.save(ss);
+        ss.seekg(0);
+
+        // Build a ContextFreeLoadTable from the separately obtained metadata.
+        auto meta = src.metadata();
+        auto table = svs::lib::ContextFreeLoadTable(meta.get());
+
+        // Capture the pointer to the current read position inside the stream buffer.
+        auto* expected_ptr = svs::io::current_ptr<float>(ss);
+        CATCH_REQUIRE(expected_ptr != nullptr);
+
+        // Load the view — data_ must point into the stringstream's internal buffer.
+        auto view = svs::data::SimpleDataView<float>::load(table, ss);
+        CATCH_REQUIRE(view.data() == expected_ptr);
+        CATCH_REQUIRE(view.size() == src.size());
+        CATCH_REQUIRE(view.dimensions() == src.dimensions());
+        CATCH_REQUIRE(svs_test::data::is_sequential(view));
+    }
+
+    CATCH_SECTION("Load SimpleDataView throws on non-memory stream") {
+        auto src = svs::data::SimpleData<float>(3, 2);
+        auto meta = src.metadata();
+        auto table = svs::lib::ContextFreeLoadTable(meta.get());
+
+        // A std::istringstream backed by a pre-built string is a memory stream;
+        // use a custom non-memory streambuf to trigger the exception path.
+        struct NonMemStreamBuf : std::streambuf {};
+        NonMemStreamBuf buf;
+        std::istream non_mem_stream(&buf);
+        CATCH_REQUIRE_THROWS_AS(
+            (svs::data::SimpleDataView<float>::load(table, non_mem_stream)),
+            svs::ANNException
         );
     }
 }

--- a/tests/svs/core/io/memstream.cpp
+++ b/tests/svs/core/io/memstream.cpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <span>
@@ -256,7 +257,6 @@ CATCH_TEST_CASE("spanstream current_ptr", "[core][io][mmap]") {
         auto* expected = text + i;
         auto match = (current == expected) && (*current == text[i]);
         CATCH_REQUIRE(match);
-        // CATCH_REQUIRE(svs::io::current_ptr<char>(iss) == text + i);
         iss.ignore(1);
     }
 

--- a/tests/svs/core/io/memstream.cpp
+++ b/tests/svs/core/io/memstream.cpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
+#include <span>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -159,7 +160,7 @@ CATCH_TEST_CASE("mmstream open throws on missing file", "[core][io][mmap]") {
     auto missing = svs_test::prepare_temp_directory_v2() / "mmstream_missing.bin";
 
     auto stream = svs::io::mmstream{};
-    CATCH_REQUIRE_THROWS_AS(stream.open(missing), std::system_error);
+    CATCH_REQUIRE_THROWS_AS(stream.open(missing), svs::lib::ANNException);
 }
 
 CATCH_TEST_CASE("is_memory_stream", "[core][io][mmap]") {
@@ -175,6 +176,11 @@ CATCH_TEST_CASE("is_memory_stream", "[core][io][mmap]") {
     // std::stringstream is an in-memory stream.
     auto ss = std::stringstream("test");
     CATCH_REQUIRE(svs::io::is_memory_stream(ss));
+
+    // svs::io::spanstream is an in-memory stream.
+    char buffer[] = "span";
+    auto span = svs::io::ispanstream(std::span<char>{buffer});
+    CATCH_REQUIRE(svs::io::is_memory_stream(span));
 
     // std::ifstream is NOT an in-memory stream.
     auto ifs = std::ifstream(path);
@@ -234,5 +240,114 @@ CATCH_TEST_CASE("current_ptr", "[core][io][mmap]") {
         auto empty_iss = std::istringstream("");
         CATCH_REQUIRE(svs::io::is_memory_stream(empty_iss));
         CATCH_REQUIRE(svs::io::current_ptr<char>(empty_iss) == nullptr);
+    }
+}
+
+CATCH_TEST_CASE("spanstream current_ptr", "[core][io][mmap]") {
+    char text[] =
+        "Hello, world!"; // Note: not a string literal, so we can take its address.
+    auto iss = svs::io::ispanstream(std::span<char>{text});
+    auto* base_ptr = svs::io::current_ptr<char>(iss);
+    CATCH_REQUIRE(base_ptr != nullptr);
+    CATCH_REQUIRE(*base_ptr == 'H');
+
+    for (std::size_t i = 0; i < std::strlen(text); ++i) {
+        auto* current = svs::io::current_ptr<char>(iss);
+        auto* expected = text + i;
+        auto match = (current == expected) && (*current == text[i]);
+        CATCH_REQUIRE(match);
+        // CATCH_REQUIRE(svs::io::current_ptr<char>(iss) == text + i);
+        iss.ignore(1);
+    }
+
+    // After reading all characters, current_ptr should point to the null terminator.
+    CATCH_REQUIRE(svs::io::current_ptr<char>(iss) == text + std::strlen(text));
+    CATCH_REQUIRE(*svs::io::current_ptr<char>(iss) == '\0');
+}
+
+CATCH_TEST_CASE("ispanstream span() getter and setter", "[core][io][mmap]") {
+    char text1[] = "First";
+    char text2[] = "Second";
+
+    auto stream = svs::io::ispanstream(std::span<char>{text1});
+
+    // Test getter
+    auto s1 = stream.rdbuf()->span();
+    CATCH_REQUIRE(s1.data() == text1);
+    CATCH_REQUIRE(s1.size() == 6);
+
+    // Test setter with new span
+    stream.rdbuf()->span(std::span<char>{text2});
+    auto s2 = stream.rdbuf()->span();
+    CATCH_REQUIRE(s2.data() == text2);
+    CATCH_REQUIRE(s2.size() == 7);
+
+    // Verify position resets to beginning
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == text2);
+    CATCH_REQUIRE(*svs::io::current_ptr<char>(stream) == 'S');
+}
+
+CATCH_TEST_CASE("ispanstream with empty span", "[core][io][mmap]") {
+    std::span<char> empty;
+    auto stream = svs::io::ispanstream(empty);
+
+    CATCH_REQUIRE(stream.rdbuf()->span().empty());
+    CATCH_REQUIRE(svs::io::is_memory_stream(stream));
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == nullptr);
+    CATCH_REQUIRE(stream.rdbuf()->span().size() == 0);
+
+    // Setting non-empty span should work
+    char text[] = "data";
+    stream.rdbuf()->span(std::span<char>{text});
+    CATCH_REQUIRE(!stream.rdbuf()->span().empty());
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == text);
+}
+
+CATCH_TEST_CASE("MemoryStreamAllocator", "[core][io][mmap]") {
+    // Create a buffer with float data
+    float data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+
+    auto run_allocator_checks = [&](std::istream& stream) {
+        auto allocator = svs::io::MemoryStreamAllocator<float>(stream);
+
+        // Allocate 3 times, each time 2 floats
+        auto* p0 = allocator.allocate(2);
+        auto* p1 = allocator.allocate(2);
+        auto* p2 = allocator.allocate(2);
+
+        // Verify pointers are contiguous
+        CATCH_REQUIRE(p1 == p0 + 2);
+        CATCH_REQUIRE(p2 == p1 + 2);
+        CATCH_REQUIRE(p2 == p0 + 4);
+
+        // Verify data integrity
+        CATCH_REQUIRE(p0[0] == data[0]);
+        CATCH_REQUIRE(p0[1] == data[1]);
+        CATCH_REQUIRE(p1[0] == data[2]);
+        CATCH_REQUIRE(p1[1] == data[3]);
+        CATCH_REQUIRE(p2[0] == data[4]);
+        CATCH_REQUIRE(p2[1] == data[5]);
+    };
+
+    CATCH_SECTION("mmstream") {
+        auto path = svs_test::prepare_temp_directory_v2() / "allocator_contiguous.bin";
+        {
+            auto out = std::ofstream(path, std::ios::binary);
+            out.write(reinterpret_cast<const char*>(data), sizeof(data));
+        }
+        auto stream = svs::io::mmstream(path);
+        run_allocator_checks(stream);
+    }
+
+    CATCH_SECTION("ispanstream") {
+        auto bytes = std::span<char>{reinterpret_cast<char*>(data), sizeof(data)};
+        auto stream = svs::io::ispanstream(bytes);
+        run_allocator_checks(stream);
+    }
+
+    CATCH_SECTION("std::stringstream") {
+        auto stream = std::stringstream(std::ios::in | std::ios::out | std::ios::binary);
+        stream.write(reinterpret_cast<const char*>(data), sizeof(data));
+        run_allocator_checks(stream);
     }
 }

--- a/tests/svs/core/io/memstream.cpp
+++ b/tests/svs/core/io/memstream.cpp
@@ -48,7 +48,8 @@ std::filesystem::path create_empty_file(const std::string& name) {
 CATCH_TEST_CASE("mmstreambuf reads and seeks", "[core][io][mmap]") {
     auto path = write_file("mmstream_data.bin", "0123456789");
 
-    auto buf = svs::io::mmstreambuf(path);
+    auto buf = svs::io::mmstreambuf{};
+    buf.open(path);
     CATCH_REQUIRE(buf.is_open());
     CATCH_REQUIRE(buf.size() == 10);
 
@@ -79,8 +80,9 @@ CATCH_TEST_CASE("mmstreambuf reads and seeks", "[core][io][mmap]") {
 CATCH_TEST_CASE("mmstreambuf handles empty files", "[core][io][mmap]") {
     auto path = create_empty_file("mmstream_empty.bin");
 
-    auto buf = svs::io::mmstreambuf(path);
-    CATCH_REQUIRE(buf.is_open());
+    auto buf = svs::io::mmstreambuf{};
+    CATCH_REQUIRE_THROWS_AS(buf.open(path), svs::lib::ANNException);
+    CATCH_REQUIRE(!buf.is_open());
     CATCH_REQUIRE(buf.size() == 0);
     CATCH_REQUIRE(buf.sgetc() == std::char_traits<char>::eof());
 }
@@ -88,7 +90,8 @@ CATCH_TEST_CASE("mmstreambuf handles empty files", "[core][io][mmap]") {
 CATCH_TEST_CASE("mmstreambuf supports move operations", "[core][io][mmap]") {
     auto path = write_file("mmstream_move.bin", "abcdef");
 
-    auto source = svs::io::mmstreambuf(path);
+    auto source = svs::io::mmstreambuf{};
+    source.open(path);
     CATCH_REQUIRE(source.pubseekpos(2, std::ios_base::in) == 2);
 
     auto moved = svs::io::mmstreambuf(std::move(source));
@@ -150,17 +153,10 @@ CATCH_TEST_CASE("current_ptr pointer semantics", "[core][io][mmap]") {
 
     stream.close();
     CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == nullptr);
-
-    auto empty_path = create_empty_file("mmstream_ptrs_empty.bin");
-    auto empty_stream = svs::io::mmstream(empty_path);
-    CATCH_REQUIRE(svs::io::current_ptr<char>(empty_stream) == nullptr);
 }
 
 CATCH_TEST_CASE("mmstream open throws on missing file", "[core][io][mmap]") {
     auto missing = svs_test::prepare_temp_directory_v2() / "mmstream_missing.bin";
-
-    auto buf = svs::io::mmstreambuf{};
-    CATCH_REQUIRE_THROWS_AS(buf.open(missing), std::system_error);
 
     auto stream = svs::io::mmstream{};
     CATCH_REQUIRE_THROWS_AS(stream.open(missing), std::system_error);
@@ -231,14 +227,6 @@ CATCH_TEST_CASE("current_ptr", "[core][io][mmap]") {
     {
         auto ifs = std::ifstream(path, std::ios::binary);
         CATCH_REQUIRE(svs::io::current_ptr<float>(ifs) == nullptr);
-    }
-
-    // ---- empty mmstream: in-memory but empty, must return nullptr ----
-    {
-        auto empty_path = create_empty_file("memstream_ptr_empty.bin");
-        auto empty_mm = svs::io::mmstream(empty_path);
-        CATCH_REQUIRE(svs::io::is_memory_stream(empty_mm));
-        CATCH_REQUIRE(svs::io::current_ptr<char>(empty_mm) == nullptr);
     }
 
     // ---- empty std::istringstream: in-memory but empty, must return nullptr ----

--- a/tests/svs/core/io/memstream.cpp
+++ b/tests/svs/core/io/memstream.cpp
@@ -142,8 +142,6 @@ CATCH_TEST_CASE("current_ptr pointer semantics", "[core][io][mmap]") {
         stream.ignore(1);
     }
 
-    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == nullptr);
-
     stream.seekg(0, std::ios_base::beg);
     CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == b);
 

--- a/tests/svs/core/io/memstream.cpp
+++ b/tests/svs/core/io/memstream.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "svs/core/io/memstream.h"
+
+#include "tests/utils/utils.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace {
+std::filesystem::path write_file(const std::string& name, const std::string& contents) {
+    auto path = svs_test::prepare_temp_directory_v2() / name;
+    auto out = std::ofstream(path, std::ios::binary);
+    out << contents;
+    out.close();
+    return path;
+}
+
+std::filesystem::path create_empty_file(const std::string& name) {
+    auto path = svs_test::prepare_temp_directory_v2() / name;
+    std::ofstream(path, std::ios::binary).close();
+    return path;
+}
+} // namespace
+
+CATCH_TEST_CASE("mmstreambuf reads and seeks", "[core][io][mmap]") {
+    auto path = write_file("mmstream_data.bin", "0123456789");
+
+    auto buf = svs::io::mmstreambuf(path);
+    CATCH_REQUIRE(buf.is_open());
+    CATCH_REQUIRE(buf.size() == 10);
+
+    CATCH_REQUIRE(buf.sgetc() == '0');
+    CATCH_REQUIRE(buf.sbumpc() == '0');
+    CATCH_REQUIRE(buf.sgetc() == '1');
+
+    CATCH_REQUIRE(buf.pubseekoff(4, std::ios_base::beg, std::ios_base::in) == 4);
+    CATCH_REQUIRE(buf.sgetc() == '4');
+
+    CATCH_REQUIRE(buf.pubseekoff(-1, std::ios_base::cur, std::ios_base::in) == 3);
+    CATCH_REQUIRE(buf.sgetc() == '3');
+
+    CATCH_REQUIRE(buf.pubseekoff(-1, std::ios_base::beg, std::ios_base::in) == -1);
+    CATCH_REQUIRE(buf.pubseekoff(1, std::ios_base::end, std::ios_base::in) == -1);
+
+    CATCH_REQUIRE(buf.pubseekpos(9, std::ios_base::in) == 9);
+    CATCH_REQUIRE(buf.sgetc() == '9');
+
+    CATCH_REQUIRE(buf.pubseekpos(10, std::ios_base::in) == 10);
+    CATCH_REQUIRE(buf.sgetc() == std::char_traits<char>::eof());
+
+    buf.close();
+    CATCH_REQUIRE(!buf.is_open());
+    CATCH_REQUIRE(buf.size() == 0);
+}
+
+CATCH_TEST_CASE("mmstreambuf handles empty files", "[core][io][mmap]") {
+    auto path = create_empty_file("mmstream_empty.bin");
+
+    auto buf = svs::io::mmstreambuf(path);
+    CATCH_REQUIRE(buf.is_open());
+    CATCH_REQUIRE(buf.size() == 0);
+    CATCH_REQUIRE(buf.sgetc() == std::char_traits<char>::eof());
+}
+
+CATCH_TEST_CASE("mmstreambuf supports move operations", "[core][io][mmap]") {
+    auto path = write_file("mmstream_move.bin", "abcdef");
+
+    auto source = svs::io::mmstreambuf(path);
+    CATCH_REQUIRE(source.pubseekpos(2, std::ios_base::in) == 2);
+
+    auto moved = svs::io::mmstreambuf(std::move(source));
+    CATCH_REQUIRE(moved.is_open());
+    CATCH_REQUIRE(!source.is_open());
+    CATCH_REQUIRE(moved.sgetc() == 'c');
+
+    auto assigned = svs::io::mmstreambuf{};
+    assigned = std::move(moved);
+    CATCH_REQUIRE(assigned.is_open());
+    CATCH_REQUIRE(!moved.is_open());
+    CATCH_REQUIRE(assigned.sgetc() == 'c');
+}
+
+CATCH_TEST_CASE("mmstream provides istream interface", "[core][io][mmap]") {
+    auto path = write_file("mmstream_stream.bin", "line1\nline2\n");
+
+    auto stream = svs::io::mmstream(path);
+    CATCH_REQUIRE(stream.is_open());
+    CATCH_REQUIRE(stream.size() == 12);
+
+    auto line = std::string{};
+    std::getline(stream, line);
+    CATCH_REQUIRE(line == "line1");
+
+    stream.seekg(0, std::ios_base::beg);
+    std::getline(stream, line);
+    CATCH_REQUIRE(line == "line1");
+
+    stream.seekg(6, std::ios_base::beg);
+    std::getline(stream, line);
+    CATCH_REQUIRE(line == "line2");
+
+    stream.close();
+    CATCH_REQUIRE(!stream.is_open());
+    CATCH_REQUIRE(stream.eof());
+}
+
+CATCH_TEST_CASE("current_ptr pointer semantics", "[core][io][mmap]") {
+    auto path = write_file("mmstream_ptrs.bin", "ABCDE");
+    auto stream = svs::io::mmstream(path);
+
+    auto* b = svs::io::current_ptr<char>(stream);
+    CATCH_REQUIRE(b != nullptr);
+    CATCH_REQUIRE(*b == 'A');
+
+    for (std::size_t i = 0; i < stream.size(); ++i) {
+        CATCH_REQUIRE(
+            svs::io::current_ptr<char>(stream) == b + static_cast<std::ptrdiff_t>(i)
+        );
+        stream.ignore(1);
+    }
+
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == nullptr);
+
+    stream.seekg(0, std::ios_base::beg);
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == b);
+
+    stream.seekg(3, std::ios_base::beg);
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == b + 3);
+
+    stream.close();
+    CATCH_REQUIRE(svs::io::current_ptr<char>(stream) == nullptr);
+
+    auto empty_path = create_empty_file("mmstream_ptrs_empty.bin");
+    auto empty_stream = svs::io::mmstream(empty_path);
+    CATCH_REQUIRE(svs::io::current_ptr<char>(empty_stream) == nullptr);
+}
+
+CATCH_TEST_CASE("mmstream open throws on missing file", "[core][io][mmap]") {
+    auto missing = svs_test::prepare_temp_directory_v2() / "mmstream_missing.bin";
+
+    auto buf = svs::io::mmstreambuf{};
+    CATCH_REQUIRE_THROWS_AS(buf.open(missing), std::system_error);
+
+    auto stream = svs::io::mmstream{};
+    CATCH_REQUIRE_THROWS_AS(stream.open(missing), std::system_error);
+}
+
+CATCH_TEST_CASE("is_memory_stream", "[core][io][mmap]") {
+    // mmstream is an in-memory stream.
+    auto path = write_file("mmstream_inmem.bin", "hello");
+    auto mm = svs::io::mmstream(path);
+    CATCH_REQUIRE(svs::io::is_memory_stream(mm));
+
+    // std::istringstream is an in-memory stream.
+    auto iss = std::istringstream("world");
+    CATCH_REQUIRE(svs::io::is_memory_stream(iss));
+
+    // std::stringstream is an in-memory stream.
+    auto ss = std::stringstream("test");
+    CATCH_REQUIRE(svs::io::is_memory_stream(ss));
+
+    // std::ifstream is NOT an in-memory stream.
+    auto ifs = std::ifstream(path);
+    CATCH_REQUIRE(!svs::io::is_memory_stream(ifs));
+}
+
+CATCH_TEST_CASE("current_ptr", "[core][io][mmap]") {
+    // ---- mmstream ----
+    // Write 3 floats to a binary file and open it as an mmstream.
+    const std::array<float, 3> data = {1.0f, 2.0f, 3.0f};
+    auto path = svs_test::prepare_temp_directory_v2() / "memstream_ptr.bin";
+    {
+        auto out = std::ofstream(path, std::ios::binary);
+        out.write(reinterpret_cast<const char*>(data.data()), sizeof(data));
+    }
+
+    auto mm = svs::io::mmstream(path);
+    auto* p0 = svs::io::current_ptr<float>(mm);
+    CATCH_REQUIRE(p0 != nullptr);
+    CATCH_REQUIRE(*p0 == data[0]);
+
+    // Reading one float worth of bytes advances current() by sizeof(float).
+    mm.ignore(static_cast<std::streamsize>(sizeof(float)));
+    auto* p1 = svs::io::current_ptr<float>(mm);
+    CATCH_REQUIRE(p1 == p0 + 1);
+    CATCH_REQUIRE(*p1 == data[1]);
+
+    // Seeking back to the start returns the same base pointer.
+    mm.seekg(0, std::ios_base::beg);
+    CATCH_REQUIRE(svs::io::current_ptr<float>(mm) == p0);
+
+    // After close the stream is not in-memory anymore: returns nullptr.
+    mm.close();
+    CATCH_REQUIRE(svs::io::current_ptr<float>(mm) == nullptr);
+
+    // ---- std::istringstream ----
+    // Build a string with known byte content, then read it back as chars.
+    const std::string text = "ABCDE";
+    auto iss = std::istringstream(text);
+    auto* cp0 = svs::io::current_ptr<char>(iss);
+    CATCH_REQUIRE(cp0 != nullptr);
+    CATCH_REQUIRE(*cp0 == 'A');
+
+    iss.ignore(2);
+    auto* cp1 = svs::io::current_ptr<char>(iss);
+    CATCH_REQUIRE(cp1 == cp0 + 2);
+    CATCH_REQUIRE(*cp1 == 'C');
+
+    // ---- std::ifstream — not in-memory: must return nullptr ----
+    {
+        auto ifs = std::ifstream(path, std::ios::binary);
+        CATCH_REQUIRE(svs::io::current_ptr<float>(ifs) == nullptr);
+    }
+
+    // ---- empty mmstream: in-memory but empty, must return nullptr ----
+    {
+        auto empty_path = create_empty_file("memstream_ptr_empty.bin");
+        auto empty_mm = svs::io::mmstream(empty_path);
+        CATCH_REQUIRE(svs::io::is_memory_stream(empty_mm));
+        CATCH_REQUIRE(svs::io::current_ptr<char>(empty_mm) == nullptr);
+    }
+
+    // ---- empty std::istringstream: in-memory but empty, must return nullptr ----
+    {
+        auto empty_iss = std::istringstream("");
+        CATCH_REQUIRE(svs::io::is_memory_stream(empty_iss));
+        CATCH_REQUIRE(svs::io::current_ptr<char>(empty_iss) == nullptr);
+    }
+}

--- a/tests/svs/index/flat/flat.cpp
+++ b/tests/svs/index/flat/flat.cpp
@@ -144,4 +144,162 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
             }
         }
     }
+
+    CATCH_SECTION("Load Flat with SimpleDataView pointing to in-memory stream buffer") {
+        // We will load the FlatIndex's data as a SimpleDataView directly from the stream,
+        // without copying.
+        using ViewData_t = svs::data::SimpleDataView<Data_t::element_type>;
+
+        // Save the full index to a stringstream.
+        auto ss = std::stringstream{};
+        index.save(ss);
+        ss.seekg(0);
+
+        // Load the FlatIndex from the stream.
+        auto loaded_index = svs::Flat::assemble<float, ViewData_t>(
+            ss, dist, svs::threads::DefaultThreadPool(1)
+        );
+
+        CATCH_REQUIRE(loaded_index.size() == index.size());
+        CATCH_REQUIRE(loaded_index.dimensions() == index.dimensions());
+
+        auto loaded_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+        loaded_index.search(loaded_results.view(), queries.cview(), {});
+
+        // Compare results - should be identical
+        for (size_t q = 0; q < queries.size(); ++q) {
+            for (size_t i = 0; i < num_neighbors; ++i) {
+                CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                CATCH_REQUIRE(
+                    loaded_results.distance(q, i) ==
+                    Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                );
+            }
+        }
+
+        // We cannot extract the pointer to the FlatIndex's internal data directly.
+        // To validate if the loaded Flat index is zero-copy,
+        // we will load a separate SimpleDataView, modify the view's data and check if it
+        // reflects in the loaded index's data. Load a SimpleDataView (zero-copy): its data_
+        // must point into ss's buffer. We should follow the stream layout written by
+        // FlatIndex::assemble:
+        ss.seekg(0);
+        // First: load deserializer.
+        auto deserializer = svs::lib::detail::Deserializer::build(ss);
+        CATCH_REQUIRE(deserializer.is_native());
+        // Second: load vectors data
+        auto view = svs::lib::load_from_stream<ViewData_t>(ss);
+
+        CATCH_REQUIRE(view.size() == index.size());
+        CATCH_REQUIRE(view.dimensions() == index.dimensions());
+        // Check if view's data pointer points into the stringstream's internal buffer
+        // (i.e., zero-copy).
+        CATCH_REQUIRE(view.data() > svs::io::begin_ptr<float>(ss));
+        CATCH_REQUIRE(view.data() < svs::io::end_ptr<float>(ss));
+        // Now update the view's data and check if it reflects in the loaded index (since it
+        // should be zero-copy). For that we will copy a vector from queries into the view's
+        // data and check if the get_distance() result changes accordingly.
+        auto data_index =
+            std::rand() % view.size(); // Randomly select a data point to modify.
+        auto query_index =
+            std::rand() % queries.size(); // Randomly select a query to test against.
+        auto original_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        // Verify that original distance is correct before modification.
+        CATCH_REQUIRE(
+            original_distance == Catch::Approx(svs::distance::compute(
+                                                   dist,
+                                                   view.get_datum(data_index),
+                                                   queries.get_datum(query_index)
+                                               ))
+                                     .epsilon(1e-5)
+        );
+        // Modify the view's data by copying a query vector into it.
+        view.set_datum(data_index, queries.get_datum(query_index));
+        // Now the distance from the modified data point to the query should be zero (or
+        // very close to zero due to floating point precision), since we copied the query
+        // vector into the data point.
+        auto modified_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
+    }
+
+    CATCH_SECTION("Load Flat with SimpleDataView from memory mapped file") {
+        using ViewData_t = svs::data::SimpleDataView<float>;
+
+        svs::lib::UniqueTempDirectory tempdir{"svs_flat_save"};
+        auto index_path = tempdir.get() / "index.bin";
+        auto os = std::ofstream{index_path, std::ios::binary};
+        index.save(os);
+        os.close();
+
+        auto index_is = svs::io::mmstream(index_path);
+        // Load the FlatIndex from the stream.
+        auto loaded_index = svs::Flat::assemble<float, ViewData_t>(
+            index_is, dist, svs::threads::DefaultThreadPool(1)
+        );
+
+        CATCH_REQUIRE(loaded_index.size() == index.size());
+        CATCH_REQUIRE(loaded_index.dimensions() == index.dimensions());
+
+        auto loaded_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+        loaded_index.search(loaded_results.view(), queries.cview(), {});
+
+        // Compare results - should be identical
+        for (size_t q = 0; q < queries.size(); ++q) {
+            for (size_t i = 0; i < num_neighbors; ++i) {
+                CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                CATCH_REQUIRE(
+                    loaded_results.distance(q, i) ==
+                    Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                );
+            }
+        }
+
+        // We cannot extract the pointer to the FlatIndex's internal data directly.
+        // To validate if the loaded Flat index is zero-copy,
+        // we will load a separate SimpleDataView, modify the view's data and check if it
+        // reflects in the loaded index's data. Load a SimpleDataView (zero-copy): its data_
+        // must point into ss's buffer. We should follow the stream layout written by
+        // FlatIndex::assemble:
+        auto view_is = svs::io::mmstream(index_path);
+        // First: load deserializer.
+        auto deserializer = svs::lib::detail::Deserializer::build(view_is);
+        CATCH_REQUIRE(deserializer.is_native());
+        // Second: load vectors data
+        auto view = svs::lib::load_from_stream<ViewData_t>(view_is);
+
+        CATCH_REQUIRE(view.size() == index.size());
+        CATCH_REQUIRE(view.dimensions() == index.dimensions());
+        // Check if view's data pointer points into the stringstream's internal buffer
+        // (i.e., zero-copy).
+        CATCH_REQUIRE(view.data() > svs::io::begin_ptr<float>(view_is));
+        CATCH_REQUIRE(view.data() < svs::io::end_ptr<float>(view_is));
+        // Now update the view's data and check if it reflects in the loaded index (since it
+        // should be zero-copy). For that we will copy a vector from queries into the view's
+        // data and check if the get_distance() result changes accordingly.
+        auto data_index =
+            std::rand() % view.size(); // Randomly select a data point to modify.
+        auto query_index =
+            std::rand() % queries.size(); // Randomly select a query to test against.
+        auto original_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        // Verify that original distance is correct before modification.
+        CATCH_REQUIRE(
+            original_distance == Catch::Approx(svs::distance::compute(
+                                                   dist,
+                                                   view.get_datum(data_index),
+                                                   queries.get_datum(query_index)
+                                               ))
+                                     .epsilon(1e-5)
+        );
+        // Modify the view's data by copying a query vector into it.
+        view.set_datum(data_index, queries.get_datum(query_index));
+        // Now the distance from the modified data point to the query should be zero (or
+        // very close to zero due to floating point precision), since we copied the query
+        // vector into the data point.
+        auto modified_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
+    }
 }

--- a/tests/svs/index/flat/flat.cpp
+++ b/tests/svs/index/flat/flat.cpp
@@ -145,7 +145,7 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
         }
     }
 
-    CATCH_SECTION("Load Flat with SimpleDataView pointing to in-memory stream buffer") {
+    CATCH_SECTION("Load with pointing to in-memory stream buffer") {
         // We will load the FlatIndex's data as a SimpleDataView directly from the stream,
         // without copying.
         using ViewData_t = svs::data::SimpleDataView<Data_t::element_type>;
@@ -224,7 +224,7 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
         CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
     }
 
-    CATCH_SECTION("Load Flat with SimpleDataView from memory mapped file") {
+    CATCH_SECTION("Load with SimpleDataView pointing to memory mapped file") {
         using ViewData_t = svs::data::SimpleDataView<float>;
 
         svs::lib::UniqueTempDirectory tempdir{"svs_flat_save"};

--- a/tests/svs/index/flat/flat.cpp
+++ b/tests/svs/index/flat/flat.cpp
@@ -148,7 +148,10 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
     CATCH_SECTION("Load with pointing to in-memory stream buffer") {
         // We will load the FlatIndex's data as a SimpleDataView directly from the stream,
         // without copying.
-        using ViewData_t = svs::data::SimpleDataView<Data_t::element_type>;
+        using ViewData_t = svs::data::SimpleData<
+            Data_t::element_type,
+            svs::Dynamic,
+            svs::io::MemoryStreamAllocator<Data_t::element_type>>;
 
         // Save the full index to a stringstream.
         auto ss = std::stringstream{};
@@ -225,7 +228,10 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
     }
 
     CATCH_SECTION("Load with SimpleDataView pointing to memory mapped file") {
-        using ViewData_t = svs::data::SimpleDataView<float>;
+        using ViewData_t = svs::data::SimpleData<
+            Data_t::element_type,
+            svs::Dynamic,
+            svs::io::MemoryStreamAllocator<Data_t::element_type>>;
 
         svs::lib::UniqueTempDirectory tempdir{"svs_flat_save"};
         auto index_path = tempdir.get() / "index.bin";

--- a/tests/svs/index/flat/flat.cpp
+++ b/tests/svs/index/flat/flat.cpp
@@ -21,6 +21,7 @@
 #include "svs/orchestrators/exhaustive.h"
 
 // tests
+#include "tests/utils/generators.h"
 #include "tests/utils/test_dataset.h"
 
 // catch2
@@ -81,6 +82,9 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
     // Load test data
     auto data = Data_t::load(test_dataset::data_svs_file());
     auto queries = test_dataset::queries();
+    auto data_id_generator = svs_test::make_generator<size_t>(size_t{0}, data.size() - 1);
+    auto query_id_generator =
+        svs_test::make_generator<size_t>(size_t{0}, queries.size() - 1);
 
     // Build index
     Distance_t dist;
@@ -202,10 +206,11 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
         // Now update the view's data and check if it reflects in the loaded index (since it
         // should be zero-copy). For that we will copy a vector from queries into the view's
         // data and check if the get_distance() result changes accordingly.
-        auto data_index =
-            std::rand() % view.size(); // Randomly select a data point to modify.
-        auto query_index =
-            std::rand() % queries.size(); // Randomly select a query to test against.
+
+        // Randomly select a data point to modify.
+        auto data_index = svs_test::generate(data_id_generator);
+        // Randomly select a query to test against.
+        auto query_index = svs_test::generate(query_id_generator);
         auto original_distance =
             loaded_index.get_distance(data_index, queries.get_datum(query_index));
         // Verify that original distance is correct before modification.
@@ -284,10 +289,11 @@ CATCH_TEST_CASE("Flat Index Save and Load", "[flat][index][saveload]") {
         // Now update the view's data and check if it reflects in the loaded index (since it
         // should be zero-copy). For that we will copy a vector from queries into the view's
         // data and check if the get_distance() result changes accordingly.
-        auto data_index =
-            std::rand() % view.size(); // Randomly select a data point to modify.
-        auto query_index =
-            std::rand() % queries.size(); // Randomly select a query to test against.
+
+        // Randomly select a data point to modify.
+        auto data_index = svs_test::generate(data_id_generator);
+        // Randomly select a query to test against.
+        auto query_index = svs_test::generate(query_id_generator);
         auto original_distance =
             loaded_index.get_distance(data_index, queries.get_datum(query_index));
         // Verify that original distance is correct before modification.

--- a/tests/svs/index/vamana/index.cpp
+++ b/tests/svs/index/vamana/index.cpp
@@ -33,6 +33,7 @@
 #include <catch2/catch_approx.hpp>
 
 // tests
+#include "tests/utils/generators.h"
 #include "tests/utils/test_dataset.h"
 #include "tests/utils/utils.h"
 #include "tests/utils/vamana_reference.h"
@@ -189,6 +190,8 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
     const size_t N = 128;
     using Eltype = float;
     auto data = svs::data::SimpleData<Eltype, N>::load(test_dataset::data_svs_file());
+    auto data_id_generator = svs_test::make_generator<size_t>(size_t{0}, data.size() - 1);
+
     auto graph = svs::graphs::SimpleGraph<uint32_t>(data.size(), 64);
     svs::distance::DistanceL2 distance_function;
     uint32_t entry_point = 0;
@@ -207,6 +210,9 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
 
     const size_t NUM_NEIGHBORS = 10;
     auto queries = test_dataset::queries();
+    auto query_id_generator =
+        svs_test::make_generator<size_t>(size_t{0}, queries.size() - 1);
+
     auto search_params = svs::index::vamana::VamanaSearchParameters{};
     search_params.buffer_config_ = svs::index::vamana::SearchBufferConfig{NUM_NEIGHBORS};
 
@@ -346,10 +352,11 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
         // Now update the view's data and check if it reflects in the loaded index (since it
         // should be zero-copy). For that we will copy a vector from queries into the view's
         // data and check if the get_distance() result changes accordingly.
-        auto data_index =
-            std::rand() % view.size(); // Randomly select a data point to modify.
-        auto query_index =
-            std::rand() % queries.size(); // Randomly select a query to test against.
+
+        // Randomly select a data point to modify.
+        auto data_index = svs_test::generate(data_id_generator);
+        // Randomly select a query to test against.
+        auto query_index = svs_test::generate(query_id_generator);
         auto original_distance =
             loaded_index.get_distance(data_index, queries.get_datum(query_index));
         // Verify that original distance is correct before modification.
@@ -441,10 +448,11 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
         // Now update the view's data and check if it reflects in the loaded index (since it
         // should be zero-copy). For that we will copy a vector from queries into the view's
         // data and check if the get_distance() result changes accordingly.
-        auto data_index =
-            std::rand() % view.size(); // Randomly select a data point to modify.
-        auto query_index =
-            std::rand() % queries.size(); // Randomly select a query to test against.
+
+        // Randomly select a data point to modify.
+        auto data_index = svs_test::generate(data_id_generator);
+        // Randomly select a query to test against.
+        auto query_index = svs_test::generate(query_id_generator);
         auto original_distance =
             loaded_index.get_distance(data_index, queries.get_datum(query_index));
         // Verify that original distance is correct before modification.
@@ -561,6 +569,8 @@ CATCH_TEST_CASE("Vamana Index Save and Load SQ", "[vamana][index][saveload][scal
     auto data = Data_t::compress(
         svs::data::SimpleData<Eltype, N>::load(test_dataset::data_svs_file())
     );
+    auto data_id_generator = svs_test::make_generator<size_t>(size_t{0}, data.size() - 1);
+
     svs::distance::DistanceL2 distance_function;
     auto threadpool = svs::threads::DefaultThreadPool(1);
 
@@ -572,6 +582,9 @@ CATCH_TEST_CASE("Vamana Index Save and Load SQ", "[vamana][index][saveload][scal
 
     const size_t NUM_NEIGHBORS = 10;
     auto queries = test_dataset::queries();
+    auto query_id_generator =
+        svs_test::make_generator<size_t>(size_t{0}, queries.size() - 1);
+
     auto search_params = svs::index::vamana::VamanaSearchParameters{};
     search_params.buffer_config_ = svs::index::vamana::SearchBufferConfig{NUM_NEIGHBORS};
 
@@ -639,10 +652,11 @@ CATCH_TEST_CASE("Vamana Index Save and Load SQ", "[vamana][index][saveload][scal
         // Now update the view's data and check if it reflects in the loaded index (since it
         // should be zero-copy). For that we will copy a vector from queries into the view's
         // data and check if the get_distance() result changes accordingly.
-        auto data_index =
-            std::rand() % view.size(); // Randomly select a data point to modify.
-        auto query_index =
-            std::rand() % queries.size(); // Randomly select a query to test against.
+
+        // Randomly select a data point to modify.
+        auto data_index = svs_test::generate(data_id_generator);
+        // Randomly select a query to test against.
+        auto query_index = svs_test::generate(query_id_generator);
         auto original_distance =
             loaded_index.get_distance(data_index, queries.get_datum(query_index));
         // Verify that original distance is correct before modification.

--- a/tests/svs/index/vamana/index.cpp
+++ b/tests/svs/index/vamana/index.cpp
@@ -283,8 +283,10 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
     CATCH_SECTION("Load with pointing to in-memory stream buffer") {
         // We will load the Vamana index's data as a SimpleDataView directly from the
         // stream, without copying.
-        using ViewData_t = svs::data::SimpleDataView<Eltype, N>;
-        using Graph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+        using ViewData_t =
+            svs::data::SimpleData<Eltype, N, svs::io::MemoryStreamAllocator<Eltype>>;
+        using Graph_t =
+            svs::graphs::SimpleGraph<uint32_t, svs::io::MemoryStreamAllocator<uint32_t>>;
 
         // Save the full index to a stringstream.
         auto ss = std::stringstream{};
@@ -372,8 +374,10 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
     CATCH_SECTION("Load with SimpleDataView pointing to memory mapped file") {
         // We will load the Vamana index's data as a SimpleDataView directly from the
         // stream, without copying.
-        using ViewData_t = svs::data::SimpleDataView<Eltype, N>;
-        using Graph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+        using ViewData_t =
+            svs::data::SimpleData<Eltype, N, svs::io::MemoryStreamAllocator<Eltype>>;
+        using Graph_t =
+            svs::graphs::SimpleGraph<uint32_t, svs::io::MemoryStreamAllocator<uint32_t>>;
 
         // Save the full index to a file
         svs::lib::UniqueTempDirectory tempdir{"svs_flat_save"};
@@ -549,8 +553,10 @@ CATCH_TEST_CASE("Vamana Index Save and Load SQ", "[vamana][index][saveload][scal
     const size_t N = 128;
     using Eltype = std::int8_t;
     using Data_t = SQDataset<Eltype>;
-    using ViewData_t = SQDataset<Eltype, svs::Dynamic, svs::View<Eltype>>;
-    using ViewGraph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+    using ViewData_t =
+        SQDataset<Eltype, svs::Dynamic, svs::io::MemoryStreamAllocator<Eltype>>;
+    using ViewGraph_t =
+        svs::graphs::SimpleGraph<uint32_t, svs::io::MemoryStreamAllocator<uint32_t>>;
 
     auto data = Data_t::compress(
         svs::data::SimpleData<Eltype, N>::load(test_dataset::data_svs_file())

--- a/tests/svs/index/vamana/index.cpp
+++ b/tests/svs/index/vamana/index.cpp
@@ -22,9 +22,11 @@
 #include "svs/core/logging.h"
 
 // svs
+#include "svs/extensions/vamana/scalar.h"
 #include "svs/index/vamana/build_params.h"
 #include "svs/lib/preprocessor.h"
 #include "svs/orchestrators/vamana.h"
+#include "svs/quantization/scalar/scalar.h"
 
 // catch2
 #include "catch2/catch_test_macros.hpp"
@@ -538,5 +540,122 @@ CATCH_TEST_CASE("Vamana Index Default Parameters", "[long][parameter][vamana]") 
         CATCH_REQUIRE(
             index.get_full_search_history() == svs::VAMANA_USE_FULL_SEARCH_HISTORY_DEFAULT
         );
+    }
+}
+
+CATCH_TEST_CASE("Vamana Index Save and Load SQ", "[vamana][index][saveload][scalar]") {
+    using namespace svs::quantization::scalar;
+
+    const size_t N = 128;
+    using Eltype = std::int8_t;
+    using Data_t = SQDataset<Eltype>;
+    using ViewData_t = SQDataset<Eltype, svs::Dynamic, svs::View<Eltype>>;
+    using ViewGraph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+
+    auto data = Data_t::compress(
+        svs::data::SimpleData<Eltype, N>::load(test_dataset::data_svs_file())
+    );
+    svs::distance::DistanceL2 distance_function;
+    auto threadpool = svs::threads::DefaultThreadPool(1);
+
+    // Build the VamanaIndex with the test logger
+    svs::index::vamana::VamanaBuildParameters buildParams(1.2, 64, 10, 20, 10, true);
+    auto index = svs::Vamana::build<float>(
+        buildParams, std::move(data), distance_function, std::move(threadpool)
+    );
+
+    const size_t NUM_NEIGHBORS = 10;
+    auto queries = test_dataset::queries();
+    auto search_params = svs::index::vamana::VamanaSearchParameters{};
+    search_params.buffer_config_ = svs::index::vamana::SearchBufferConfig{NUM_NEIGHBORS};
+
+    auto results = svs::QueryResult<size_t>(queries.size(), NUM_NEIGHBORS);
+    index.search(results.view(), queries.cview(), search_params);
+
+    CATCH_SECTION("Load with SQ pointing to in-memory stream buffer") {
+        // We will load the Vamana index's data as a SQDataset 'view' directly from the
+        // stream, without copying.
+        // Save the full index to a stringstream.
+        auto ss = std::stringstream{};
+        index.save(ss);
+
+        // Load the Vamana index from the stream.
+        ss.seekg(0);
+        auto loaded_index = svs::Vamana::assemble<float, ViewData_t>(
+            ss, distance_function, svs::threads::DefaultThreadPool(1)
+        );
+
+        CATCH_REQUIRE(loaded_index.size() == index.size());
+        CATCH_REQUIRE(loaded_index.dimensions() == index.dimensions());
+
+        auto loaded_results = svs::QueryResult<size_t>(queries.size(), NUM_NEIGHBORS);
+
+        loaded_index.search(loaded_results.view(), queries.cview(), search_params);
+        for (size_t q = 0; q < queries.size(); ++q) {
+            for (size_t i = 0; i < NUM_NEIGHBORS; ++i) {
+                CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                CATCH_REQUIRE(
+                    loaded_results.distance(q, i) ==
+                    Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                );
+            }
+        }
+
+        // We cannot extract the pointer to the FlatIndex's internal data directly.
+        // To validate if the loaded Flat index is zero-copy,
+        // we will load a separate SimpleDataView, modify the view's data and check if it
+        // reflects in the loaded index's data. Load a SimpleDataView (zero-copy): its data_
+        // must point into ss's buffer. We should follow the stream layout written by
+        // Vamana::assemble:
+        ss.seekg(0);
+        // First: load deserializer.
+        auto deserializer = svs::lib::detail::Deserializer::build(ss);
+        CATCH_REQUIRE(deserializer.is_native());
+        // Following svs::index::vamana::auto_assemble():
+        // Second: load config parameters (not strictly necessary to validate the view
+        // loading, but good to check that we can load the parameters as expected).
+        auto config_parameters =
+            svs::lib::load_from_stream<svs::index::vamana::VamanaIndexParameters>(ss);
+        CATCH_REQUIRE(config_parameters.build_parameters == buildParams);
+        // Third: load vectors data
+        auto view = svs::lib::load_from_stream<ViewData_t>(ss);
+        CATCH_REQUIRE(view.size() == index.size());
+        CATCH_REQUIRE(view.dimensions() == index.dimensions());
+        // Fourth: load graph (also not strictly necessary, but good to check that we can
+        // load the graph as expected).
+        auto graph = svs::lib::load_from_stream<ViewGraph_t>(ss);
+        CATCH_REQUIRE(graph.n_nodes() == index.size());
+
+        // Check if view's data pointer points into the stringstream's internal buffer
+        // (i.e., zero-copy).
+        CATCH_REQUIRE(view.get_datum(0).data() > svs::io::begin_ptr<Eltype>(ss));
+        CATCH_REQUIRE(view.get_datum(0).data() < svs::io::end_ptr<Eltype>(ss));
+        // Now update the view's data and check if it reflects in the loaded index (since it
+        // should be zero-copy). For that we will copy a vector from queries into the view's
+        // data and check if the get_distance() result changes accordingly.
+        auto data_index =
+            std::rand() % view.size(); // Randomly select a data point to modify.
+        auto query_index =
+            std::rand() % queries.size(); // Randomly select a query to test against.
+        auto original_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        // Verify that original distance is correct before modification.
+        CATCH_REQUIRE(
+            original_distance ==
+            Catch::Approx(
+                svs::index::vamana::extensions::get_distance_ext(
+                    view, distance_function, data_index, queries.get_datum(query_index)
+                )
+            )
+                .epsilon(1e-5)
+        );
+        // Modify the view's data by copying a query vector into it.
+        view.set_datum(data_index, queries.get_datum(query_index));
+        // Now the distance from the modified data point to the query should be zero (or
+        // very close to zero due to floating point precision), since we copied the query
+        // vector into the data point.
+        auto modified_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
     }
 }

--- a/tests/svs/index/vamana/index.cpp
+++ b/tests/svs/index/vamana/index.cpp
@@ -277,6 +277,188 @@ CATCH_TEST_CASE("Vamana Index Save and Load", "[vamana][index][saveload]") {
             }
         }
     }
+
+    CATCH_SECTION("Load with pointing to in-memory stream buffer") {
+        // We will load the Vamana index's data as a SimpleDataView directly from the
+        // stream, without copying.
+        using ViewData_t = svs::data::SimpleDataView<Eltype, N>;
+        using Graph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+
+        // Save the full index to a stringstream.
+        auto ss = std::stringstream{};
+        index.save(ss);
+
+        // Load the Vamana index from the stream.
+        ss.seekg(0);
+        auto loaded_index = svs::Vamana::assemble<float, ViewData_t>(
+            ss, distance_function, svs::threads::DefaultThreadPool(1)
+        );
+
+        CATCH_REQUIRE(loaded_index.size() == index.size());
+        CATCH_REQUIRE(loaded_index.dimensions() == index.dimensions());
+
+        auto loaded_results = svs::QueryResult<size_t>(queries.size(), NUM_NEIGHBORS);
+
+        loaded_index.search(loaded_results.view(), queries.cview(), search_params);
+        for (size_t q = 0; q < queries.size(); ++q) {
+            for (size_t i = 0; i < NUM_NEIGHBORS; ++i) {
+                CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                CATCH_REQUIRE(
+                    loaded_results.distance(q, i) ==
+                    Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                );
+            }
+        }
+
+        // We cannot extract the pointer to the FlatIndex's internal data directly.
+        // To validate if the loaded Flat index is zero-copy,
+        // we will load a separate SimpleDataView, modify the view's data and check if it
+        // reflects in the loaded index's data. Load a SimpleDataView (zero-copy): its data_
+        // must point into ss's buffer. We should follow the stream layout written by
+        // Vamana::assemble:
+        ss.seekg(0);
+        // First: load deserializer.
+        auto deserializer = svs::lib::detail::Deserializer::build(ss);
+        CATCH_REQUIRE(deserializer.is_native());
+        // Following svs::index::vamana::auto_assemble():
+        // Second: load config parameters (not strictly necessary to validate the view
+        // loading, but good to check that we can load the parameters as expected).
+        auto config_parameters =
+            svs::lib::load_from_stream<svs::index::vamana::VamanaIndexParameters>(ss);
+        CATCH_REQUIRE(config_parameters.build_parameters == buildParams);
+        // Third: load vectors data
+        auto view = svs::lib::load_from_stream<ViewData_t>(ss);
+        CATCH_REQUIRE(view.size() == index.size());
+        CATCH_REQUIRE(view.dimensions() == index.dimensions());
+        // Fourth: load graph (also not strictly necessary, but good to check that we can
+        // load the graph as expected).
+        auto graph = svs::lib::load_from_stream<Graph_t>(ss);
+        CATCH_REQUIRE(graph.n_nodes() == index.size());
+
+        // Check if view's data pointer points into the stringstream's internal buffer
+        // (i.e., zero-copy).
+        CATCH_REQUIRE(view.data() > svs::io::begin_ptr<float>(ss));
+        CATCH_REQUIRE(view.data() < svs::io::end_ptr<float>(ss));
+        // Now update the view's data and check if it reflects in the loaded index (since it
+        // should be zero-copy). For that we will copy a vector from queries into the view's
+        // data and check if the get_distance() result changes accordingly.
+        auto data_index =
+            std::rand() % view.size(); // Randomly select a data point to modify.
+        auto query_index =
+            std::rand() % queries.size(); // Randomly select a query to test against.
+        auto original_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        // Verify that original distance is correct before modification.
+        CATCH_REQUIRE(
+            original_distance == Catch::Approx(svs::distance::compute(
+                                                   distance_function,
+                                                   view.get_datum(data_index),
+                                                   queries.get_datum(query_index)
+                                               ))
+                                     .epsilon(1e-5)
+        );
+        // Modify the view's data by copying a query vector into it.
+        view.set_datum(data_index, queries.get_datum(query_index));
+        // Now the distance from the modified data point to the query should be zero (or
+        // very close to zero due to floating point precision), since we copied the query
+        // vector into the data point.
+        auto modified_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
+    }
+
+    CATCH_SECTION("Load with SimpleDataView pointing to memory mapped file") {
+        // We will load the Vamana index's data as a SimpleDataView directly from the
+        // stream, without copying.
+        using ViewData_t = svs::data::SimpleDataView<Eltype, N>;
+        using Graph_t = svs::graphs::SimpleGraph<uint32_t, svs::View<uint32_t>>;
+
+        // Save the full index to a file
+        svs::lib::UniqueTempDirectory tempdir{"svs_flat_save"};
+        auto index_path = tempdir.get() / "index.bin";
+        auto os = std::ofstream{index_path, std::ios::binary};
+        index.save(os);
+        os.close();
+
+        auto index_is = svs::io::mmstream(index_path);
+
+        // Load the Vamana index from the stream.
+        auto loaded_index = svs::Vamana::assemble<float, ViewData_t>(
+            index_is, distance_function, svs::threads::DefaultThreadPool(1)
+        );
+
+        CATCH_REQUIRE(loaded_index.size() == index.size());
+        CATCH_REQUIRE(loaded_index.dimensions() == index.dimensions());
+
+        auto loaded_results = svs::QueryResult<size_t>(queries.size(), NUM_NEIGHBORS);
+
+        loaded_index.search(loaded_results.view(), queries.cview(), search_params);
+        for (size_t q = 0; q < queries.size(); ++q) {
+            for (size_t i = 0; i < NUM_NEIGHBORS; ++i) {
+                CATCH_REQUIRE(loaded_results.index(q, i) == results.index(q, i));
+                CATCH_REQUIRE(
+                    loaded_results.distance(q, i) ==
+                    Catch::Approx(results.distance(q, i)).epsilon(1e-5)
+                );
+            }
+        }
+
+        // We cannot extract the pointer to the FlatIndex's internal data directly.
+        // To validate if the loaded Flat index is zero-copy,
+        // we will load a separate SimpleDataView, modify the view's data and check if it
+        // reflects in the loaded index's data. Load a SimpleDataView (zero-copy): its data_
+        // must point into ss's buffer. We should follow the stream layout written by
+        // Vamana::assemble:
+        auto view_is = svs::io::mmstream(index_path);
+        // First: load deserializer.
+        auto deserializer = svs::lib::detail::Deserializer::build(view_is);
+        CATCH_REQUIRE(deserializer.is_native());
+        // Following svs::index::vamana::auto_assemble():
+        // Second: load config parameters (not strictly necessary to validate the view
+        // loading, but good to check that we can load the parameters as expected).
+        auto config_parameters =
+            svs::lib::load_from_stream<svs::index::vamana::VamanaIndexParameters>(view_is);
+        CATCH_REQUIRE(config_parameters.build_parameters == buildParams);
+        // Third: load vectors data
+        auto view = svs::lib::load_from_stream<ViewData_t>(view_is);
+        CATCH_REQUIRE(view.size() == index.size());
+        CATCH_REQUIRE(view.dimensions() == index.dimensions());
+        // Fourth: load graph (also not strictly necessary, but good to check that we can
+        // load the graph as expected).
+        auto graph = svs::lib::load_from_stream<Graph_t>(view_is);
+        CATCH_REQUIRE(graph.n_nodes() == index.size());
+
+        // Check if view's data pointer points into the stringstream's internal buffer
+        // (i.e., zero-copy).
+        CATCH_REQUIRE(view.data() > svs::io::begin_ptr<float>(view_is));
+        CATCH_REQUIRE(view.data() < svs::io::end_ptr<float>(view_is));
+        // Now update the view's data and check if it reflects in the loaded index (since it
+        // should be zero-copy). For that we will copy a vector from queries into the view's
+        // data and check if the get_distance() result changes accordingly.
+        auto data_index =
+            std::rand() % view.size(); // Randomly select a data point to modify.
+        auto query_index =
+            std::rand() % queries.size(); // Randomly select a query to test against.
+        auto original_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        // Verify that original distance is correct before modification.
+        CATCH_REQUIRE(
+            original_distance == Catch::Approx(svs::distance::compute(
+                                                   distance_function,
+                                                   view.get_datum(data_index),
+                                                   queries.get_datum(query_index)
+                                               ))
+                                     .epsilon(1e-5)
+        );
+        // Modify the view's data by copying a query vector into it.
+        view.set_datum(data_index, queries.get_datum(query_index));
+        // Now the distance from the modified data point to the query should be zero (or
+        // very close to zero due to floating point precision), since we copied the query
+        // vector into the data point.
+        auto modified_distance =
+            loaded_index.get_distance(data_index, queries.get_datum(query_index));
+        CATCH_REQUIRE(modified_distance == Catch::Approx(0.0).epsilon(1e-5));
+    }
 }
 
 CATCH_TEST_CASE("Vamana Index Default Parameters", "[long][parameter][vamana]") {

--- a/tests/svs/quantization/scalar/scalar.cpp
+++ b/tests/svs/quantization/scalar/scalar.cpp
@@ -276,8 +276,10 @@ CATCH_TEST_CASE("Testing SQDataset", "[quantization][scalar]") {
         auto* expected_ptr = svs::io::current_ptr<sq_dtype>(ss);
         CATCH_REQUIRE(expected_ptr != nullptr);
 
-        auto view =
-            scalar::SQDataset<sq_dtype, svs::Dynamic, svs::View<sq_dtype>>::load(table, ss);
+        auto view = scalar::SQDataset<
+            sq_dtype,
+            svs::Dynamic,
+            svs::io::MemoryStreamAllocator<sq_dtype>>::load(table, ss);
         CATCH_REQUIRE(view.size() == src.size());
         CATCH_REQUIRE(view.dimensions() == src.dimensions());
         CATCH_REQUIRE(view.get_scale() == src.get_scale());

--- a/tests/svs/quantization/scalar/scalar.cpp
+++ b/tests/svs/quantization/scalar/scalar.cpp
@@ -28,6 +28,9 @@
 // catch2
 #include "catch2/catch_test_macros.hpp"
 
+// stdlib
+#include <sstream>
+
 namespace scalar = svs::quantization::scalar;
 
 template <typename T, size_t N> void test_sq_top() {
@@ -253,6 +256,42 @@ CATCH_TEST_CASE("Testing SQDataset", "[quantization][scalar]") {
     CATCH_SECTION("SQDataset compression") {
         test_sq_top<std::int8_t, 128>();
         test_sq_top<std::int16_t, 128>();
+    }
+
+    CATCH_SECTION("Load SQDataset view pointed to stringstream") {
+        using sq_dtype = std::int8_t;
+        auto src = scalar::SQDataset<sq_dtype>(5, 4);
+        svs_test::data::set_sequential(src);
+        src.set_scale(0.5F);
+        src.set_bias(-3.0F);
+
+        auto ss = std::stringstream{};
+        src.save(ss);
+        ss.seekg(0);
+
+        auto meta = src.metadata();
+        auto table = svs::lib::ContextFreeLoadTable(meta.get());
+
+        // Capture the pointer to the current read position inside the stream buffer.
+        auto* expected_ptr = svs::io::current_ptr<sq_dtype>(ss);
+        CATCH_REQUIRE(expected_ptr != nullptr);
+
+        auto view =
+            scalar::SQDataset<sq_dtype, svs::Dynamic, svs::View<sq_dtype>>::load(table, ss);
+        CATCH_REQUIRE(view.size() == src.size());
+        CATCH_REQUIRE(view.dimensions() == src.dimensions());
+        CATCH_REQUIRE(view.get_scale() == src.get_scale());
+        CATCH_REQUIRE(view.get_bias() == src.get_bias());
+        CATCH_REQUIRE(view.get_datum(0).data() == expected_ptr);
+
+        for (size_t i = 0; i < src.size(); ++i) {
+            auto a = src.get_datum(i);
+            auto b = view.get_datum(i);
+            CATCH_REQUIRE(a.size() == b.size());
+            for (size_t j = 0; j < a.size(); ++j) {
+                CATCH_REQUIRE(a[j] == b[j]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This pull request adds to *CPP Runtime API* support for loading vector search indices (`FlatIndex` and `VamanaIndex`) from memory-mapped files and memory buffers, in addition to existing stream-based loading. It introduces new API methods, updates internal implementations to manage mapped resources, and adds comprehensive tests to ensure correct behavior for all supported storage types.

**Major new features:**

* Added `map_to_file` and `map_to_memory` static methods to both `FlatIndex` and `VamanaIndex` classes, allowing indices to be loaded directly from memory-mapped files or memory buffers, in addition to streams. [[1]](diffhunk://#diff-f0ce1183b8c5cdcfb5695de7ef342a3ce24612b210a8fad6fe8f4167799be62fR47-R57) [[2]](diffhunk://#diff-e52a73179f9dd7aa990c9af03f06154b793cf3256e56ea8d8178b8c5d2b94830R98-R113)
* Implemented the corresponding logic in the source files, including resource management to keep memory-mapped streams alive as long as the index exists. [[1]](diffhunk://#diff-de6dee0ad3cb3c5b014b2ca41a35e8c25ca89109df0de05b3dd80417f8db9e2bR118-R146) [[2]](diffhunk://#diff-cb41fef6bcf1500fc3dabe9bc538b25703996206e6f7f374555052288497666dR147-R179)

**Internal implementation changes:**

* Added and updated constructors and helper methods in `FlatIndexImpl` and `VamanaIndexImpl` to support mapping from streams, and to manage the lifetime of mapped streams via `unique_ptr` members. [[1]](diffhunk://#diff-50945d5825b1f8b17cbaed0910af9040ba9e711b60c8efd4999d6e2d16bc7f10R115-R147) [[2]](diffhunk://#diff-50945d5825b1f8b17cbaed0910af9040ba9e711b60c8efd4999d6e2d16bc7f10R170-R171) [[3]](diffhunk://#diff-31655c4c3c9cc43507e931a4a94cbf313f4e72adef18b0f10e02ae0f5bae4212L390-R402) [[4]](diffhunk://#diff-31655c4c3c9cc43507e931a4a94cbf313f4e72adef18b0f10e02ae0f5bae4212R455-R476) [[5]](diffhunk://#diff-31655c4c3c9cc43507e931a4a94cbf313f4e72adef18b0f10e02ae0f5bae4212R485)
* Included necessary headers for memory stream support in relevant files. [[1]](diffhunk://#diff-50945d5825b1f8b17cbaed0910af9040ba9e711b60c8efd4999d6e2d16bc7f10R25) [[2]](diffhunk://#diff-31655c4c3c9cc43507e931a4a94cbf313f4e72adef18b0f10e02ae0f5bae4212R30) [[3]](diffhunk://#diff-31a8431da16fec6682d01bfb952126041e07e7cdb6c3c03c2df81da014feec75R22) [[4]](diffhunk://#diff-17ac30bf9c39ba9ca45f79e0855076cc2b5a79be3b160fc165121c8ea46f9e20R24)
* Updated dataset loading logic to enforce that view allocators are only used with memory streams, improving safety and correctness.

**Testing improvements:**

* Added a generic test helper (`write_and_map_index`) and comprehensive test cases to verify correct loading and querying of indices from memory-mapped files for all supported storage kinds and index types. [[1]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R158-R233) [[2]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R534-R543) [[3]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R781-R797) [[4]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R815-R831) [[5]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R849-R865) [[6]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R883-R899) [[7]](diffhunk://#diff-768acd95c233a557d7242ba34004166ed310f1a8abb2aa050390f40f1be06865R918-R935)