### PR TITLE
Fix manylinux2014 Docker build: add sslverify=0 for oneAPI repo

### DIFF
--- a/docker/x86_64/manylinux2014/oneAPI.repo
+++ b/docker/x86_64/manylinux2014/oneAPI.repo
@@ -5,3 +5,4 @@ enabled=1
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+sslverify=0


### PR DESCRIPTION
## Summary
- CentOS 7 (manylinux2014 base image) has reached EOL and its CA certificate bundle is permanently frozen
- Intel's `yum.repos.intel.com` now uses a TLS certificate whose CA is not in CentOS 7's trust store, causing `curl#60 - "Peer's Certificate issuer is not recognized."` during Docker build
- Adds `sslverify=0` to the oneAPI yum repo config to skip TLS cert validation. Package integrity is still protected by `gpgcheck=1` and `repo_gpgcheck=1`

## Test plan
- [ ] CI Build Wheel job passes with this change
- [ ] Verified CI fails without this change (reverted and confirmed `curl#60` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)