### PR TITLE
Remove non IVF runtime bindings branching

### DIFF
--- a/.github/scripts/build-cpp-runtime-bindings.sh
+++ b/.github/scripts/build-cpp-runtime-bindings.sh
@@ -18,15 +18,13 @@ set -e  # Exit on error
 # Source environment setup (for compiler)
 source /etc/bashrc || true
 
-# Source MKL environment if IVF is enabled
-if [ "${ENABLE_IVF:-OFF}" = "ON" ]; then
-    if [ -f /opt/intel/oneapi/setvars.sh ]; then
-        source /opt/intel/oneapi/setvars.sh --include-intel-llvm 2>/dev/null || true
-        echo "MKL sourced: MKLROOT=${MKLROOT}"
-    else
-        echo "ERROR: IVF enabled but MKL setvars.sh not found"
-        exit 1
-    fi
+# Source MKL environment (required for IVF)
+if [ -f /opt/intel/oneapi/setvars.sh ]; then
+    source /opt/intel/oneapi/setvars.sh --include-intel-llvm 2>/dev/null || true
+    echo "MKL sourced: MKLROOT=${MKLROOT}"
+else
+    echo "ERROR: MKL setvars.sh not found"
+    exit 1
 fi
 
 # Create build+install directories for cpp runtime bindings
@@ -42,7 +40,7 @@ CMAKE_ARGS=(
     "-DCMAKE_INSTALL_PREFIX=/workspace/install_cpp_bindings"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DSVS_RUNTIME_ENABLE_LVQ_LEANVEC=${ENABLE_LVQ_LEANVEC:-ON}"
-    "-DSVS_RUNTIME_ENABLE_IVF=${ENABLE_IVF:-OFF}"
+    "-DSVS_RUNTIME_ENABLE_IVF=ON"
 )
 
 if [ -n "$SVS_URL" ]; then
@@ -64,7 +62,7 @@ find /workspace/bindings/cpp/build_cpp_bindings -name '*.a' -delete 2>/dev/null 
 find /workspace/bindings/cpp/build_cpp_bindings -name '*.so*' -not -path '*/tests/*' -not -name 'libsvs_runtime*' -delete 2>/dev/null || true
 # Use /workspace for temp files to avoid filling up /tmp during LTO compilation
 mkdir -p /workspace/tmp
-TMPDIR=/workspace/tmp ENABLE_LVQ_LEANVEC=${ENABLE_LVQ_LEANVEC:-ON} ENABLE_IVF=${ENABLE_IVF:-OFF} SVS_URL="${SVS_URL}" SUFFIX="${SUFFIX}" conda build bindings/cpp/conda-recipe --output-folder /workspace/conda-bld
+TMPDIR=/workspace/tmp ENABLE_LVQ_LEANVEC=${ENABLE_LVQ_LEANVEC:-ON} SVS_URL="${SVS_URL}" SUFFIX="${SUFFIX}" conda build bindings/cpp/conda-recipe --output-folder /workspace/conda-bld
 
 # Create tarball with symlink for compatibility
 cd /workspace/install_cpp_bindings && \

--- a/.github/scripts/test-cpp-runtime-bindings.sh
+++ b/.github/scripts/test-cpp-runtime-bindings.sh
@@ -35,7 +35,7 @@ conda install -y mkl=2025.3 mkl-devel=2025.3
 conda install -y /runtime_conda/libsvs-runtime-*.conda
 
 # Validate python and C++ tests against FAISS CI
-TODO: clone main branch upon merge of https://github.com/facebookresearch/faiss/pull/4801
+# TODO: clone main branch upon merge of https://github.com/facebookresearch/faiss/pull/4801
 git clone --branch ib/svs_ivf https://github.com/ibhati/faiss.git
 cd faiss
 

--- a/.github/scripts/test-cpp-runtime-bindings.sh
+++ b/.github/scripts/test-cpp-runtime-bindings.sh
@@ -35,7 +35,8 @@ conda install -y mkl=2025.3 mkl-devel=2025.3
 conda install -y /runtime_conda/libsvs-runtime-*.conda
 
 # Validate python and C++ tests against FAISS CI
-git clone https://github.com/facebookresearch/faiss.git
+TODO: clone main branch upon merge of https://github.com/facebookresearch/faiss/pull/4801
+git clone --branch ib/svs_ivf https://github.com/ibhati/faiss.git
 cd faiss
 
 echo "==============================================="

--- a/.github/scripts/test-cpp-runtime-bindings.sh
+++ b/.github/scripts/test-cpp-runtime-bindings.sh
@@ -35,14 +35,7 @@ conda install -y mkl=2025.3 mkl-devel=2025.3
 conda install -y /runtime_conda/libsvs-runtime-*.conda
 
 # Validate python and C++ tests against FAISS CI
-ENABLE_IVF="${ENABLE_IVF:-OFF}"
-if [ "${ENABLE_IVF}" = "ON" ]; then
-  echo "IVF enabled: cloning forked FAISS with IVF support"
-  git clone --branch ib/svs_ivf https://github.com/ibhati/faiss.git
-else
-  echo "IVF disabled: cloning upstream FAISS"
-  git clone https://github.com/facebookresearch/faiss.git
-fi
+git clone https://github.com/facebookresearch/faiss.git
 cd faiss
 
 echo "==============================================="

--- a/.github/scripts/test-cpp-runtime-unit.sh
+++ b/.github/scripts/test-cpp-runtime-unit.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Source environment setup (for compiler and MKL)
+source /etc/bashrc || true
+if [ -f /opt/intel/oneapi/setvars.sh ]; then
+    source /opt/intel/oneapi/setvars.sh 2>/dev/null || true
+fi
+
+CTEST_DIR="bindings/cpp/build_cpp_bindings/tests"
+
+# Check if running on Intel hardware or if LVQ/LeanVec is not enabled
+if grep -q "GenuineIntel" /proc/cpuinfo || [ "${ENABLE_LVQ_LEANVEC}" != "ON" ]; then
+    ctest --test-dir $CTEST_DIR --output-on-failure --no-tests=error --verbose
+else
+    echo "Non-Intel CPU detected - running tests with LVQ/LeanVec XFAIL"
+    # Run non-LVQ/LeanVec tests normally
+    ctest --test-dir $CTEST_DIR --output-on-failure --no-tests=error --verbose -E "(LVQ|LeanVec)"
+
+    # Run LVQ/LeanVec tests expecting failure on non-Intel hardware
+    set +e
+    ctest --test-dir $CTEST_DIR --output-on-failure --verbose -R "(LVQ|LeanVec)"
+    exit_code=$?
+    set -e
+
+    if [ $exit_code -ne 0 ]; then
+        echo "XFAIL: LVQ/LeanVec ctest tests failed as expected on non-Intel hardware"
+    else
+        echo "UNEXPECTED: LVQ/LeanVec ctest tests passed on non-Intel hardware"
+        exit 1
+    fi
+fi

--- a/.github/workflows/build-cpp-runtime-bindings.yml
+++ b/.github/workflows/build-cpp-runtime-bindings.yml
@@ -81,10 +81,9 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
+            -e ENABLE_LVQ_LEANVEC=${{ matrix.enable_lvq_leanvec }} \
             svs-manylinux228:latest \
-            /bin/bash -c "source /etc/bashrc || true && \
-              if [ -f /opt/intel/oneapi/setvars.sh ]; then source /opt/intel/oneapi/setvars.sh 2>/dev/null || true; fi && \
-              ctest --test-dir bindings/cpp/build_cpp_bindings/tests --output-on-failure --no-tests=error --verbose"
+            /bin/bash /workspace/.github/scripts/test-cpp-runtime-unit.sh
 
   # Run full test script using the built artifacts
   test:

--- a/.github/workflows/build-cpp-runtime-bindings.yml
+++ b/.github/workflows/build-cpp-runtime-bindings.yml
@@ -38,16 +38,10 @@ jobs:
         include:
           - name: "with static library"
             enable_lvq_leanvec: "ON"
-            enable_ivf: "OFF"
             suffix: ""
           - name: "public only"
             enable_lvq_leanvec: "OFF"
-            enable_ivf: "OFF"
             suffix: "-public-only"
-          - name: "IVF public only"
-            enable_lvq_leanvec: "OFF"
-            enable_ivf: "ON"
-            suffix: "-ivf"
       fail-fast: false
 
     steps:
@@ -63,7 +57,6 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e ENABLE_LVQ_LEANVEC=${{ matrix.enable_lvq_leanvec }} \
-            -e ENABLE_IVF=${{ matrix.enable_ivf }} \
             -e SUFFIX=${{ matrix.suffix }} \
             svs-manylinux228:latest \
             /bin/bash .github/scripts/build-cpp-runtime-bindings.sh
@@ -88,10 +81,9 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            -e ENABLE_IVF=${{ matrix.enable_ivf }} \
             svs-manylinux228:latest \
             /bin/bash -c "source /etc/bashrc || true && \
-              if [ \"\${ENABLE_IVF}\" = 'ON' ] && [ -f /opt/intel/oneapi/setvars.sh ]; then source /opt/intel/oneapi/setvars.sh 2>/dev/null || true; fi && \
+              if [ -f /opt/intel/oneapi/setvars.sh ]; then source /opt/intel/oneapi/setvars.sh 2>/dev/null || true; fi && \
               ctest --test-dir bindings/cpp/build_cpp_bindings/tests --output-on-failure --no-tests=error --verbose"
 
   # Run full test script using the built artifacts
@@ -104,13 +96,8 @@ jobs:
         include:
           - name: "with static library"
             suffix: ""
-            enable_ivf: "OFF"
           - name: "public only"
             suffix: "-public-only"
-            enable_ivf: "OFF"
-          - name: "IVF public only"
-            suffix: "-ivf"
-            enable_ivf: "ON"
       fail-fast: false
 
     steps:
@@ -138,6 +125,5 @@ jobs:
             -v ${{ github.workspace }}/runtime_conda:/runtime_conda \
             -w /workspace \
             -e SUFFIX=${{ matrix.suffix }} \
-            -e ENABLE_IVF=${{ matrix.enable_ivf }} \
             svs-manylinux228:latest \
             /bin/bash .github/scripts/test-cpp-runtime-bindings.sh

--- a/bindings/cpp/conda-recipe/build.sh
+++ b/bindings/cpp/conda-recipe/build.sh
@@ -25,15 +25,13 @@ else
     echo "WARNING: gcc-toolset-11 not found, proceeding without sourcing it"
 fi
 
-# Source MKL environment if IVF is enabled (IVF requires MKL)
-if [ "${ENABLE_IVF:-OFF}" = "ON" ]; then
-    if [ -f /opt/intel/oneapi/setvars.sh ]; then
-        source /opt/intel/oneapi/setvars.sh --include-intel-llvm 2>/dev/null || true
-        echo "MKL sourced for IVF build: MKLROOT=${MKLROOT}"
-    else
-        echo "ERROR: IVF enabled but MKL setvars.sh not found"
-        exit 1
-    fi
+# Source MKL environment (required for IVF)
+if [ -f /opt/intel/oneapi/setvars.sh ]; then
+    source /opt/intel/oneapi/setvars.sh --include-intel-llvm 2>/dev/null || true
+    echo "MKL sourced: MKLROOT=${MKLROOT}"
+else
+    echo "ERROR: MKL setvars.sh not found"
+    exit 1
 fi
 
 # build runtime tests flag?
@@ -41,7 +39,7 @@ CMAKE_ARGS=(
     "-DCMAKE_INSTALL_PREFIX=${PREFIX}"
     "-DSVS_BUILD_RUNTIME_TESTS=OFF"
     "-DSVS_RUNTIME_ENABLE_LVQ_LEANVEC=${ENABLE_LVQ_LEANVEC:-ON}"
-    "-DSVS_RUNTIME_ENABLE_IVF=${ENABLE_IVF:-OFF}"
+    "-DSVS_RUNTIME_ENABLE_IVF=ON"
 )
 
 # Add SVS_URL if specified (for fetching static library)

--- a/bindings/cpp/conda-recipe/meta.yaml
+++ b/bindings/cpp/conda-recipe/meta.yaml
@@ -30,7 +30,6 @@ build:
   skip: true  # [not linux]
   include_recipe: False
   script_env:
-    - ENABLE_IVF
     - ENABLE_LVQ_LEANVEC
     - SUFFIX
     - SVS_URL

--- a/bindings/cpp/tests/CMakeLists.txt
+++ b/bindings/cpp/tests/CMakeLists.txt
@@ -79,15 +79,8 @@ endif()
 include(CTest)
 enable_testing()
 
-# Add the test to CTest
-add_test(NAME svs_runtime_test COMMAND svs_runtime_test)
-
-# Set test properties
-set_tests_properties(svs_runtime_test PROPERTIES
-    LABELS "runtime_bindings"
-)
-
-# Optional: Add Catch2's automatic test discovery
+# Use Catch2's automatic test discovery to register individual test cases.
+# This allows ctest -E/-R filters to target specific tests (e.g., LVQ/LeanVec).
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 catch_discover_tests(svs_runtime_test)


### PR DESCRIPTION
Build cpp runtime bindings with IVF in all github workflows now that it is stabilized. Set to ON anywhere the CMake flag is passed, and remove any higher level branches in .github workflows, scripts, and conda-recipe files