### PR TITLE
Fix: cmake version compatibility issue in C API CMakeLists.txt

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -118,7 +118,6 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
         FetchContent_Declare(
             svs
             URL ${SVS_URL}
-            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         FetchContent_MakeAvailable(svs)
         list(APPEND CMAKE_PREFIX_PATH "${svs_SOURCE_DIR}")


### PR DESCRIPTION
Resolve cmake version compatibility issue caused by using DOWNLOAD_EXTRACT_TIMESTAMP which is introduced in v.3.24

This PR fixes #317 
