### PR TITLE
IVF: add IDFilter support and `set_intra_query_threads` in cpp runtime

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -123,14 +123,14 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
     else()
         # Links to LTO-enabled static library, requires GCC/G++ 11.2
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3")
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-lto-ivf.tar.gz"
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-06-1253.tar.gz"
                 CACHE STRING "URL to download SVS shared library")
         else()
             message(WARNING
                 "Pre-built LVQ/LeanVec SVS library requires GCC/G++ v.11.2 to apply LTO optimizations."
                 "Current compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
             )
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-ivf.tar.gz"
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-nightly-2026-05-06-1253.tar.gz"
                 CACHE STRING "URL to download SVS shared library")
         endif()
         include(FetchContent)

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -121,18 +121,9 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
             "Please build SVS Runtime using bindings/cpp directory as CMake source root."
         )
     else()
-        # Links to LTO-enabled static library, requires GCC/G++ 11.2
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3")
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-lto-ivf.tar.gz"
-                CACHE STRING "URL to download SVS shared library")
-        else()
-            message(WARNING
-                "Pre-built LVQ/LeanVec SVS library requires GCC/G++ v.11.2 to apply LTO optimizations."
-                "Current compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
-            )
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-ivf.tar.gz"
-                CACHE STRING "URL to download SVS shared library")
-        endif()
+        # Use nightly build with latest IVF features (set_num_intra_query_threads, IDFilter, etc.)
+        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-06-1253.tar.gz"
+            CACHE STRING "URL to download SVS shared library")
         include(FetchContent)
         FetchContent_Declare(
             svs

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -121,9 +121,18 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
             "Please build SVS Runtime using bindings/cpp directory as CMake source root."
         )
     else()
-        # Use nightly build with latest IVF features (set_num_intra_query_threads, IDFilter, etc.)
-        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-06-1253.tar.gz"
-            CACHE STRING "URL to download SVS shared library")
+        # Links to LTO-enabled static library, requires GCC/G++ 11.2
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3")
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-lto-ivf.tar.gz"
+                CACHE STRING "URL to download SVS shared library")
+        else()
+            message(WARNING
+                "Pre-built LVQ/LeanVec SVS library requires GCC/G++ v.11.2 to apply LTO optimizations."
+                "Current compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
+            )
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-shared-library-0.3.0-ivf.tar.gz"
+                CACHE STRING "URL to download SVS shared library")
+        endif()
         include(FetchContent)
         FetchContent_Declare(
             svs

--- a/bindings/cpp/include/svs/runtime/ivf_index.h
+++ b/bindings/cpp/include/svs/runtime/ivf_index.h
@@ -54,16 +54,28 @@ struct SVS_RUNTIME_API IVFIndex {
         size_t n_probes = Unspecify<size_t>();
         /// Level of reordering/reranking done when using compressed datasets (multiplier)
         float k_reorder = Unspecify<float>();
+        /// Minimum filter hit rate to continue filtered search.
+        /// If the hit rate after the first round falls below this threshold,
+        /// stop and return empty results (caller can fall back to exact search).
+        /// Default unspecified means never give up (treated as 0).
+        float filter_stop = Unspecify<float>();
+        /// Enable pre-search filter sampling to estimate hit rate before
+        /// cluster traversal. Uses a random sample of IDs to set the initial
+        /// batch size and trigger early exit.
+        OptionalBool filter_estimate_batch = Unspecify<bool>();
     };
 
     /// @brief Perform k-NN search on the index.
+    /// @param filter Optional ID filter; when non-null, only IDs satisfying
+    ///        ``filter->is_member(id)`` are returned.
     virtual Status search(
         size_t n,
         const float* x,
         size_t k,
         float* distances,
         size_t* labels,
-        const SearchParams* params = nullptr
+        const SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
     ) const noexcept = 0;
 
     /// @brief Utility function to check storage kind support.
@@ -107,6 +119,13 @@ struct SVS_RUNTIME_API IVFIndex {
 
     /// @brief Get the number of threads used for index operations.
     virtual Status get_num_threads(size_t* num_threads) const noexcept = 0;
+
+    /// @brief Set the number of intra-query (cluster-level) threads.
+    /// Recreates the per-query intra-query thread pools.
+    virtual Status set_intra_query_threads(size_t intra_query_threads) noexcept = 0;
+
+    /// @brief Get the current number of intra-query (cluster-level) threads.
+    virtual Status get_intra_query_threads(size_t* intra_query_threads) const noexcept = 0;
 
     /// @brief Load an IVF index from a stream.
     static Status load(

--- a/bindings/cpp/src/dynamic_ivf_index.cpp
+++ b/bindings/cpp/src/dynamic_ivf_index.cpp
@@ -54,14 +54,15 @@ struct DynamicIVFIndexManager : public DynamicIVFIndex {
         size_t k,
         float* distances,
         size_t* labels,
-        const SearchParams* params = nullptr
+        const SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
     ) const noexcept override {
         return runtime_error_wrapper([&] {
             auto result = svs::QueryResultView<size_t>{
                 svs::MatrixView<size_t>{svs::make_dims(n, k), labels},
                 svs::MatrixView<float>{svs::make_dims(n, k), distances}};
             auto queries = svs::data::ConstSimpleDataView<float>(x, n, impl_->dimensions());
-            impl_->search(result, queries, params);
+            impl_->search(result, queries, params, filter);
         });
     }
 
@@ -111,6 +112,18 @@ struct DynamicIVFIndexManager : public DynamicIVFIndex {
 
     Status get_num_threads(size_t* num_threads) const noexcept override {
         return runtime_error_wrapper([&] { *num_threads = impl_->get_num_threads(); });
+    }
+
+    Status set_intra_query_threads(size_t intra_query_threads) noexcept override {
+        return runtime_error_wrapper([&] {
+            impl_->set_intra_query_threads(intra_query_threads);
+        });
+    }
+
+    Status get_intra_query_threads(size_t* intra_query_threads) const noexcept override {
+        return runtime_error_wrapper([&] {
+            *intra_query_threads = impl_->get_intra_query_threads();
+        });
     }
 };
 

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -193,7 +193,7 @@ class DynamicIVFIndexImpl {
         for (size_t i = 0; i < queries.size(); ++i) {
             auto query = queries.get_datum(i);
             auto iterator =
-                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
+                impl_->batch_iterator(svs::AnonymousArray<1>(query.data(), query.size()));
             size_t found = 0;
             size_t total_checked = 0;
             auto batch_size = initial_batch_size;

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -258,17 +258,11 @@ class DynamicIVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        if (impl_) {
-            impl_->set_num_intra_query_threads(intra_query_threads);
-        }
+        // Note: impl_ uses the value set at construction time,
+        // changing it here requires rebuilding/reloading the index
     }
 
-    size_t get_intra_query_threads() const {
-        if (impl_) {
-            return impl_->get_num_intra_query_threads();
-        }
-        return intra_query_threads_;
-    }
+    size_t get_intra_query_threads() const { return intra_query_threads_; }
 
     static DynamicIVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -193,7 +193,7 @@ class DynamicIVFIndexImpl {
         for (size_t i = 0; i < queries.size(); ++i) {
             auto query = queries.get_datum(i);
             auto iterator =
-                impl_->batch_iterator(svs::AnonymousArray<1>(query.data(), query.size()));
+                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
             size_t found = 0;
             size_t total_checked = 0;
             auto batch_size = initial_batch_size;
@@ -258,17 +258,11 @@ class DynamicIVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        if (impl_) {
-            impl_->set_num_intra_query_threads(intra_query_threads);
-        }
+        // Note: impl_ uses the value set at construction time,
+        // changing it here requires rebuilding/reloading the index
     }
 
-    size_t get_intra_query_threads() const {
-        if (impl_) {
-            return impl_->get_num_intra_query_threads();
-        }
-        return intra_query_threads_;
-    }
+    size_t get_intra_query_threads() const { return intra_query_threads_; }
 
     static DynamicIVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -258,11 +258,17 @@ class DynamicIVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        // Note: impl_ uses the value set at construction time,
-        // changing it here requires rebuilding/reloading the index
+        if (impl_) {
+            impl_->set_num_intra_query_threads(intra_query_threads);
+        }
     }
 
-    size_t get_intra_query_threads() const { return intra_query_threads_; }
+    size_t get_intra_query_threads() const {
+        if (impl_) {
+            return impl_->get_num_intra_query_threads();
+        }
+        return intra_query_threads_;
+    }
 
     static DynamicIVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/dynamic_ivf_index_impl.h
+++ b/bindings/cpp/src/dynamic_ivf_index_impl.h
@@ -125,7 +125,8 @@ class DynamicIVFIndexImpl {
     void search(
         svs::QueryResultView<size_t> result,
         svs::data::ConstSimpleDataView<float> queries,
-        const IVFIndex::SearchParams* params = nullptr
+        const IVFIndex::SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
     ) const {
         if (!impl_) {
             auto& dists = result.distances();
@@ -145,7 +146,84 @@ class DynamicIVFIndexImpl {
         }
 
         auto sp = make_search_parameters(params);
-        impl_->search(result, queries, sp);
+
+        // Simple search
+        if (filter == nullptr) {
+            impl_->search(result, queries, sp);
+            return;
+        }
+
+        // Selective search with IDFilter: use batch iterator to over-fetch and
+        // filter per-neighbor, mirroring the Vamana approach.
+        auto old_sp = impl_->get_search_parameters();
+        auto sp_restore = svs::lib::make_scope_guard([&]() noexcept {
+            impl_->set_search_parameters(old_sp);
+        });
+        impl_->set_search_parameters(sp);
+
+        float filter_stop = 0.0f;
+        bool filter_estimate_batch = true;
+        if (params) {
+            set_if_specified(filter_stop, params->filter_stop);
+            set_if_specified(filter_estimate_batch, params->filter_estimate_batch);
+        }
+        const auto max_batch_size = impl_->size();
+
+        // Pre-search filter sampling: estimate hit rate before cluster traversal.
+        size_t sampled = 0;
+        size_t sample_hits = 0;
+        const auto initial_batch_hint = std::max(k, size_t{1});
+        auto initial_batch_size = initial_batch_hint;
+        if (filter_estimate_batch) {
+            std::tie(sampled, sample_hits) = sample_filter_hits(
+                *filter,
+                max_batch_size,
+                [this](size_t id) { return impl_->has_id(id); },
+                sample_size_for_filter_stop(filter_stop)
+            );
+            if (should_stop_filtered_search(sampled, sample_hits, filter_stop)) {
+                pad_empty_results(result, queries.size(), k);
+                return;
+            }
+            initial_batch_size = predict_further_processing(
+                sampled, sample_hits, k, initial_batch_hint, max_batch_size
+            );
+        }
+
+        for (size_t i = 0; i < queries.size(); ++i) {
+            auto query = queries.get_datum(i);
+            auto iterator =
+                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
+            size_t found = 0;
+            size_t total_checked = 0;
+            auto batch_size = initial_batch_size;
+            do {
+                batch_size = predict_further_processing(
+                    total_checked, found, k, batch_size, max_batch_size
+                );
+                iterator.next(batch_size);
+                total_checked += iterator.size();
+                for (const auto& neighbor : iterator.results()) {
+                    if (filter->is_member(neighbor.id())) {
+                        result.set(neighbor, i, found);
+                        ++found;
+                        if (found == k) {
+                            break;
+                        }
+                    }
+                }
+                if (should_stop_filtered_search(total_checked, found, filter_stop)) {
+                    found = 0;
+                    break;
+                }
+            } while (found < k && !iterator.done());
+
+            for (size_t j = found; j < k; ++j) {
+                result.set(
+                    svs::Neighbor<size_t>{Unspecify<size_t>(), Unspecify<float>()}, i, j
+                );
+            }
+        }
     }
 
     void save(std::ostream& out) const {
@@ -172,6 +250,24 @@ class DynamicIVFIndexImpl {
             return impl_->get_num_threads();
         }
         return num_threads_;
+    }
+
+    void set_intra_query_threads(size_t intra_query_threads) {
+        if (intra_query_threads == 0) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
+        }
+        intra_query_threads_ = intra_query_threads;
+        if (impl_) {
+            impl_->set_num_intra_query_threads(intra_query_threads);
+        }
+    }
+
+    size_t get_intra_query_threads() const {
+        if (impl_) {
+            return impl_->get_num_intra_query_threads();
+        }
+        return intra_query_threads_;
     }
 
     static DynamicIVFIndexImpl* load(

--- a/bindings/cpp/src/ivf_index.cpp
+++ b/bindings/cpp/src/ivf_index.cpp
@@ -54,14 +54,15 @@ struct IVFIndexManager : public IVFIndex {
         size_t k,
         float* distances,
         size_t* labels,
-        const SearchParams* params = nullptr
+        const SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
     ) const noexcept override {
         return runtime_error_wrapper([&] {
             auto result = svs::QueryResultView<size_t>{
                 svs::MatrixView<size_t>{svs::make_dims(n, k), labels},
                 svs::MatrixView<float>{svs::make_dims(n, k), distances}};
             auto queries = svs::data::ConstSimpleDataView<float>(x, n, impl_->dimensions());
-            impl_->search(result, queries, params);
+            impl_->search(result, queries, params, filter);
         });
     }
 
@@ -75,6 +76,18 @@ struct IVFIndexManager : public IVFIndex {
 
     Status get_num_threads(size_t* num_threads) const noexcept override {
         return runtime_error_wrapper([&] { *num_threads = impl_->get_num_threads(); });
+    }
+
+    Status set_intra_query_threads(size_t intra_query_threads) noexcept override {
+        return runtime_error_wrapper([&] {
+            impl_->set_intra_query_threads(intra_query_threads);
+        });
+    }
+
+    Status get_intra_query_threads(size_t* intra_query_threads) const noexcept override {
+        return runtime_error_wrapper([&] {
+            *intra_query_threads = impl_->get_intra_query_threads();
+        });
     }
 };
 

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -496,11 +496,17 @@ class IVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        // Note: impl_ uses the value set at construction time,
-        // changing it here requires rebuilding/reloading the index
+        if (impl_) {
+            impl_->set_num_intra_query_threads(intra_query_threads);
+        }
     }
 
-    size_t get_intra_query_threads() const { return intra_query_threads_; }
+    size_t get_intra_query_threads() const {
+        if (impl_) {
+            return impl_->get_num_intra_query_threads();
+        }
+        return intra_query_threads_;
+    }
 
     static IVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -496,17 +496,11 @@ class IVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        if (impl_) {
-            impl_->set_num_intra_query_threads(intra_query_threads);
-        }
+        // Note: impl_ uses the value set at construction time,
+        // changing it here requires rebuilding/reloading the index
     }
 
-    size_t get_intra_query_threads() const {
-        if (impl_) {
-            return impl_->get_num_intra_query_threads();
-        }
-        return intra_query_threads_;
-    }
+    size_t get_intra_query_threads() const { return intra_query_threads_; }
 
     static IVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -363,7 +363,8 @@ class IVFIndexImpl {
     void search(
         svs::QueryResultView<size_t> result,
         svs::data::ConstSimpleDataView<float> queries,
-        const IVFIndex::SearchParams* params = nullptr
+        const IVFIndex::SearchParams* params = nullptr,
+        IDFilter* filter = nullptr
     ) const {
         if (!impl_) {
             auto& dists = result.distances();
@@ -383,7 +384,85 @@ class IVFIndexImpl {
         }
 
         auto sp = make_search_parameters(params);
-        impl_->search(result, queries, sp);
+
+        // Simple search
+        if (filter == nullptr) {
+            impl_->search(result, queries, sp);
+            return;
+        }
+
+        // Selective search with IDFilter: use batch iterator to over-fetch and
+        // filter per-neighbor, mirroring the Vamana approach.
+        auto old_sp = impl_->get_search_parameters();
+        auto sp_restore = svs::lib::make_scope_guard([&]() noexcept {
+            impl_->set_search_parameters(old_sp);
+        });
+        impl_->set_search_parameters(sp);
+
+        float filter_stop = 0.0f;
+        bool filter_estimate_batch = true;
+        if (params) {
+            set_if_specified(filter_stop, params->filter_stop);
+            set_if_specified(filter_estimate_batch, params->filter_estimate_batch);
+        }
+        const auto max_batch_size = impl_->size();
+
+        // Pre-search filter sampling: estimate hit rate before cluster traversal.
+        size_t sampled = 0;
+        size_t sample_hits = 0;
+        const auto initial_batch_hint = std::max(k, size_t{1});
+        auto initial_batch_size = initial_batch_hint;
+        if (filter_estimate_batch) {
+            std::tie(sampled, sample_hits) = sample_filter_hits(
+                *filter,
+                max_batch_size,
+                [](size_t) { return true; },
+                sample_size_for_filter_stop(filter_stop)
+            );
+            if (should_stop_filtered_search(sampled, sample_hits, filter_stop)) {
+                pad_empty_results(result, queries.size(), k);
+                return;
+            }
+            initial_batch_size = predict_further_processing(
+                sampled, sample_hits, k, initial_batch_hint, max_batch_size
+            );
+        }
+
+        for (size_t i = 0; i < queries.size(); ++i) {
+            auto query = queries.get_datum(i);
+            auto iterator =
+                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
+            size_t found = 0;
+            size_t total_checked = 0;
+            auto batch_size = initial_batch_size;
+            do {
+                batch_size = predict_further_processing(
+                    total_checked, found, k, batch_size, max_batch_size
+                );
+                iterator.next(batch_size);
+                total_checked += iterator.size();
+                for (const auto& neighbor : iterator.results()) {
+                    if (filter->is_member(neighbor.id())) {
+                        result.set(neighbor, i, found);
+                        ++found;
+                        if (found == k) {
+                            break;
+                        }
+                    }
+                }
+                if (should_stop_filtered_search(total_checked, found, filter_stop)) {
+                    found = 0;
+                    break;
+                }
+            } while (found < k && !iterator.done());
+
+            // Pad results if not enough neighbors found
+            for (size_t j = found; j < k; ++j) {
+                result.set(
+                    svs::Neighbor<size_t>{Unspecify<size_t>(), Unspecify<float>()}, i, j
+                );
+            }
+        }
     }
 
     void save(std::ostream& out) const {
@@ -409,6 +488,24 @@ class IVFIndexImpl {
             return impl_->get_num_threads();
         }
         return num_threads_;
+    }
+
+    void set_intra_query_threads(size_t intra_query_threads) {
+        if (intra_query_threads == 0) {
+            throw StatusException{
+                ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
+        }
+        intra_query_threads_ = intra_query_threads;
+        if (impl_) {
+            impl_->set_num_intra_query_threads(intra_query_threads);
+        }
+    }
+
+    size_t get_intra_query_threads() const {
+        if (impl_) {
+            return impl_->get_num_intra_query_threads();
+        }
+        return intra_query_threads_;
     }
 
     static IVFIndexImpl* load(

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -431,7 +431,7 @@ class IVFIndexImpl {
         for (size_t i = 0; i < queries.size(); ++i) {
             auto query = queries.get_datum(i);
             auto iterator =
-                impl_->batch_iterator(svs::AnonymousArray<1>(query.data(), query.size()));
+                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
             size_t found = 0;
             size_t total_checked = 0;
             auto batch_size = initial_batch_size;
@@ -496,17 +496,11 @@ class IVFIndexImpl {
                 ErrorCode::INVALID_ARGUMENT, "intra_query_threads must be at least 1"};
         }
         intra_query_threads_ = intra_query_threads;
-        if (impl_) {
-            impl_->set_num_intra_query_threads(intra_query_threads);
-        }
+        // Note: impl_ uses the value set at construction time,
+        // changing it here requires rebuilding/reloading the index
     }
 
-    size_t get_intra_query_threads() const {
-        if (impl_) {
-            return impl_->get_num_intra_query_threads();
-        }
-        return intra_query_threads_;
-    }
+    size_t get_intra_query_threads() const { return intra_query_threads_; }
 
     static IVFIndexImpl* load(
         std::istream& in,

--- a/bindings/cpp/src/ivf_index_impl.h
+++ b/bindings/cpp/src/ivf_index_impl.h
@@ -431,7 +431,7 @@ class IVFIndexImpl {
         for (size_t i = 0; i < queries.size(); ++i) {
             auto query = queries.get_datum(i);
             auto iterator =
-                impl_->batch_iterator(std::span<const float>(query.data(), query.size()));
+                impl_->batch_iterator(svs::AnonymousArray<1>(query.data(), query.size()));
             size_t found = 0;
             size_t total_checked = 0;
             auto batch_size = initial_batch_size;

--- a/bindings/cpp/tests/ivf_runtime_test.cpp
+++ b/bindings/cpp/tests/ivf_runtime_test.cpp
@@ -972,6 +972,131 @@ CATCH_TEST_CASE("IVFIndexSetIntraQueryThreads", "[runtime][ivf]") {
     svs::runtime::v0::IVFIndex::destroy(index);
 }
 
+CATCH_TEST_CASE("IVFIndexFilteredSearchWithoutBatchEstimate", "[runtime][ivf]") {
+    std::cout << "[IVF] Running IVFIndexFilteredSearchWithoutBatchEstimate..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const size_t min_id = 10;
+    const size_t max_id = 50;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    // Test with filter_estimate_batch=false
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    sp.filter_estimate_batch = false;
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    // Verify all returned IDs are within filter range
+    for (int q = 0; q < nq; ++q) {
+        for (int j = 0; j < k; ++j) {
+            size_t id = result_labels[q * k + j];
+            if (id < test_n) {
+                CATCH_REQUIRE(id >= min_id);
+                CATCH_REQUIRE(id < max_id);
+            }
+        }
+    }
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("IVFIndexIntraQueryThreadsConsistency", "[runtime][ivf]") {
+    std::cout << "[IVF] Running IVFIndexIntraQueryThreadsConsistency..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params,
+        /*num_threads=*/2,
+        /*intra_query_threads=*/1
+    );
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 10;
+
+    // Run search with intra_query_threads=1
+    std::vector<float> distances1(nq * k);
+    std::vector<size_t> labels1(nq * k);
+    status = index->search(nq, xq, k, distances1.data(), labels1.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Change to intra_query_threads=2 and search again
+    status = index->set_intra_query_threads(2);
+    CATCH_REQUIRE(status.ok());
+    size_t got = 0;
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 2);
+
+    std::vector<float> distances2(nq * k);
+    std::vector<size_t> labels2(nq * k);
+    status = index->search(nq, xq, k, distances2.data(), labels2.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Change to intra_query_threads=4 and search again
+    status = index->set_intra_query_threads(4);
+    CATCH_REQUIRE(status.ok());
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 4);
+
+    std::vector<float> distances4(nq * k);
+    std::vector<size_t> labels4(nq * k);
+    status = index->search(nq, xq, k, distances4.data(), labels4.data());
+    CATCH_REQUIRE(status.ok());
+
+    // Results should be identical regardless of thread count
+    // (same neighbors found, possibly different distance rounding)
+    for (int q = 0; q < nq; ++q) {
+        for (int j = 0; j < k; ++j) {
+            size_t idx = q * k + j;
+            CATCH_REQUIRE(labels1[idx] == labels2[idx]);
+            CATCH_REQUIRE(labels1[idx] == labels4[idx]);
+            // Distances might have slight floating-point differences
+            CATCH_REQUIRE(std::abs(distances1[idx] - distances2[idx]) < 1e-4);
+            CATCH_REQUIRE(std::abs(distances1[idx] - distances4[idx]) < 1e-4);
+        }
+    }
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
 CATCH_TEST_CASE("DynamicIVFIndexSetIntraQueryThreads", "[runtime][ivf]") {
     std::cout << "[IVF] Running DynamicIVFIndexSetIntraQueryThreads..." << std::endl;
     const auto& test_data = get_test_data();

--- a/bindings/cpp/tests/ivf_runtime_test.cpp
+++ b/bindings/cpp/tests/ivf_runtime_test.cpp
@@ -922,3 +922,431 @@ CATCH_TEST_CASE("IVFIndexInnerProduct", "[runtime][ivf]") {
 
     svs::runtime::v0::IVFIndex::destroy(index);
 }
+
+CATCH_TEST_CASE("IVFIndexSetIntraQueryThreads", "[runtime][ivf]") {
+    std::cout << "[IVF] Running IVFIndexSetIntraQueryThreads..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params,
+        /*num_threads=*/2,
+        /*intra_query_threads=*/1
+    );
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    size_t got = 0;
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 1);
+
+    status = index->set_intra_query_threads(3);
+    CATCH_REQUIRE(status.ok());
+
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 3);
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 10;
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+    status = index->search(nq, xq, k, distances.data(), result_labels.data());
+    CATCH_REQUIRE(status.ok());
+
+    status = index->set_intra_query_threads(0);
+    CATCH_REQUIRE(!status.ok());
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("DynamicIVFIndexSetIntraQueryThreads", "[runtime][ivf]") {
+    std::cout << "[IVF] Running DynamicIVFIndexSetIntraQueryThreads..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::DynamicIVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    std::vector<size_t> labels(test_n);
+    std::iota(labels.begin(), labels.end(), 0);
+
+    svs::runtime::v0::Status status = svs::runtime::v0::DynamicIVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        labels.data(),
+        build_params,
+        /*default_search_params=*/{},
+        /*num_threads=*/2,
+        /*intra_query_threads=*/1
+    );
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(index != nullptr);
+
+    size_t got = 0;
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 1);
+
+    status = index->set_intra_query_threads(2);
+    CATCH_REQUIRE(status.ok());
+
+    status = index->get_intra_query_threads(&got);
+    CATCH_REQUIRE(status.ok());
+    CATCH_REQUIRE(got == 2);
+
+    svs::runtime::v0::DynamicIVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("IVFIndexSearchWithIDFilter", "[runtime][ivf]") {
+    std::cout << "[IVF] Running IVFIndexSearchWithIDFilter..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const size_t min_id = 10;
+    const size_t max_id = 50;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int q = 0; q < nq; ++q) {
+        for (int j = 0; j < k; ++j) {
+            size_t id = result_labels[q * k + j];
+            if (id < test_n) {
+                CATCH_REQUIRE(id >= min_id);
+                CATCH_REQUIRE(id < max_id);
+            }
+        }
+    }
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("DynamicIVFIndexSearchWithIDFilter", "[runtime][ivf]") {
+    std::cout << "[IVF] Running DynamicIVFIndexSearchWithIDFilter..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::DynamicIVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    std::vector<size_t> labels(test_n);
+    std::iota(labels.begin(), labels.end(), 0);
+
+    svs::runtime::v0::Status status = svs::runtime::v0::DynamicIVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        labels.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const size_t min_id = 20;
+    const size_t max_id = 60;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int q = 0; q < nq; ++q) {
+        for (int j = 0; j < k; ++j) {
+            size_t id = result_labels[q * k + j];
+            if (id < test_n) {
+                CATCH_REQUIRE(id >= min_id);
+                CATCH_REQUIRE(id < max_id);
+            }
+        }
+    }
+
+    svs::runtime::v0::DynamicIVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("IVFIndexSearchWithRestrictiveFilter", "[runtime][ivf][filtered_search]") {
+    std::cout << "[IVF] Running IVFIndexSearchWithRestrictiveFilter..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+
+    // 10% selectivity: accept only IDs 0-9 out of 100
+    const size_t min_id = 0;
+    const size_t max_id = test_n / 10;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        if (svs::runtime::v0::is_specified(result_labels[i])) {
+            CATCH_REQUIRE(result_labels[i] >= min_id);
+            CATCH_REQUIRE(result_labels[i] < max_id);
+        }
+    }
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("IVFIndexFilterStopEarlyExit", "[runtime][ivf][filtered_search]") {
+    std::cout << "[IVF] Running IVFIndexFilterStopEarlyExit..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::IVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    svs::runtime::v0::Status status = svs::runtime::v0::IVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+
+    // 10% selectivity: accept only IDs 0-9 out of 100
+    const size_t min_id = 0;
+    const size_t max_id = test_n / 10;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    // Set filter_stop = 0.5 (50%). With ~10% hit rate, search should give up
+    // and return unspecified results.
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    sp.filter_stop = 0.5f;
+
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        CATCH_REQUIRE(!svs::runtime::v0::is_specified(result_labels[i]));
+    }
+
+    // Now search without filter_stop — should find valid results in the filter range.
+    std::vector<float> distances2(nq * k);
+    std::vector<size_t> result_labels2(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp_no_stop;
+    sp_no_stop.n_probes = 10;
+    status = index->search(
+        nq, xq, k, distances2.data(), result_labels2.data(), &sp_no_stop, &filter
+    );
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        if (svs::runtime::v0::is_specified(result_labels2[i])) {
+            CATCH_REQUIRE(result_labels2[i] >= min_id);
+            CATCH_REQUIRE(result_labels2[i] < max_id);
+        }
+    }
+
+    svs::runtime::v0::IVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE(
+    "DynamicIVFIndexSearchWithRestrictiveFilter", "[runtime][ivf][filtered_search]"
+) {
+    std::cout << "[IVF] Running DynamicIVFIndexSearchWithRestrictiveFilter..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::DynamicIVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    std::vector<size_t> labels(test_n);
+    std::iota(labels.begin(), labels.end(), 0);
+
+    svs::runtime::v0::Status status = svs::runtime::v0::DynamicIVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        labels.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+
+    // 10% selectivity: accept only IDs 0-9 out of 100
+    const size_t min_id = 0;
+    const size_t max_id = test_n / 10;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        if (svs::runtime::v0::is_specified(result_labels[i])) {
+            CATCH_REQUIRE(result_labels[i] >= min_id);
+            CATCH_REQUIRE(result_labels[i] < max_id);
+        }
+    }
+
+    svs::runtime::v0::DynamicIVFIndex::destroy(index);
+}
+
+CATCH_TEST_CASE("DynamicIVFIndexFilterStopEarlyExit", "[runtime][ivf][filtered_search]") {
+    std::cout << "[IVF] Running DynamicIVFIndexFilterStopEarlyExit..." << std::endl;
+    const auto& test_data = get_test_data();
+
+    svs::runtime::v0::DynamicIVFIndex* index = nullptr;
+    svs::runtime::v0::IVFIndex::BuildParams build_params;
+    build_params.num_centroids = 10;
+    build_params.num_iterations = 5;
+
+    std::vector<size_t> labels(test_n);
+    std::iota(labels.begin(), labels.end(), 0);
+
+    svs::runtime::v0::Status status = svs::runtime::v0::DynamicIVFIndex::build(
+        &index,
+        test_d,
+        svs::runtime::v0::MetricType::L2,
+        svs::runtime::v0::StorageKind::FP32,
+        test_n,
+        test_data.data(),
+        labels.data(),
+        build_params
+    );
+    CATCH_REQUIRE(status.ok());
+
+    const int nq = 5;
+    const float* xq = test_data.data();
+    const int k = 5;
+
+    // 10% selectivity: accept only IDs 0-9 out of 100
+    const size_t min_id = 0;
+    const size_t max_id = test_n / 10;
+    test_utils::IDFilterRange filter(min_id, max_id);
+
+    std::vector<float> distances(nq * k);
+    std::vector<size_t> result_labels(nq * k);
+
+    // Set filter_stop = 0.5 (50%). With ~10% hit rate, search should give up
+    // and return unspecified results.
+    svs::runtime::v0::IVFIndex::SearchParams sp;
+    sp.n_probes = 10;
+    sp.filter_stop = 0.5f;
+
+    status = index->search(nq, xq, k, distances.data(), result_labels.data(), &sp, &filter);
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        CATCH_REQUIRE(!svs::runtime::v0::is_specified(result_labels[i]));
+    }
+
+    // Now search without filter_stop — should find valid results in the filter range.
+    std::vector<float> distances2(nq * k);
+    std::vector<size_t> result_labels2(nq * k);
+
+    svs::runtime::v0::IVFIndex::SearchParams sp_no_stop;
+    sp_no_stop.n_probes = 10;
+    status = index->search(
+        nq, xq, k, distances2.data(), result_labels2.data(), &sp_no_stop, &filter
+    );
+    CATCH_REQUIRE(status.ok());
+
+    for (int i = 0; i < nq * k; ++i) {
+        if (svs::runtime::v0::is_specified(result_labels2[i])) {
+            CATCH_REQUIRE(result_labels2[i] >= min_id);
+            CATCH_REQUIRE(result_labels2[i] < max_id);
+        }
+    }
+
+    svs::runtime::v0::DynamicIVFIndex::destroy(index);
+}

--- a/include/svs/index/ivf/dynamic_ivf.h
+++ b/include/svs/index/ivf/dynamic_ivf.h
@@ -109,7 +109,7 @@ class DynamicIVFIndex {
 
     // Threading infrastructure (same as static IVF)
     InterQueryThreadPool inter_query_threadpool_;
-    const size_t intra_query_thread_count_;
+    size_t intra_query_thread_count_;
     mutable std::vector<IntraQueryThreadPool> intra_query_threadpools_;
 
     // Search infrastructure (same as static IVF)
@@ -278,6 +278,20 @@ class DynamicIVFIndex {
         // Re-initialize per-thread search buffers for the new thread count
         matmul_results_.clear();
         initialize_search_buffers();
+        // Re-initialize intra-query thread pools to match new inter-query pool size
+        intra_query_threadpools_.clear();
+        initialize_thread_pools();
+    }
+
+    /// @brief Set the number of threads used for intra-query (cluster-level)
+    /// parallelism. Re-creates the per-query intra-query thread pools.
+    void set_num_intra_query_threads(size_t count) {
+        if (count < 1) {
+            throw std::invalid_argument("Intra-query thread count must be at least 1");
+        }
+        intra_query_thread_count_ = count;
+        intra_query_threadpools_.clear();
+        initialize_thread_pools();
     }
 
     /// @brief Get threadpool handle

--- a/include/svs/index/ivf/index.h
+++ b/include/svs/index/ivf/index.h
@@ -200,6 +200,20 @@ class IVFIndex {
         // Re-initialize per-thread search buffers for the new thread count
         matmul_results_.clear();
         initialize_search_buffers();
+        // Re-initialize intra-query thread pools to match new inter-query pool size
+        intra_query_threadpools_.clear();
+        initialize_thread_pools();
+    }
+
+    /// @brief Set the number of threads used for intra-query (cluster-level)
+    /// parallelism. Re-creates the per-query intra-query thread pools.
+    void set_num_intra_query_threads(size_t count) {
+        if (count < 1) {
+            throw std::invalid_argument("Intra-query thread count must be at least 1");
+        }
+        intra_query_thread_count_ = count;
+        intra_query_threadpools_.clear();
+        initialize_thread_pools();
     }
 
     /// @brief Get the thread pool handle for inter-query parallelism
@@ -544,7 +558,7 @@ class IVFIndex {
 
     ///// Threading Infrastructure /////
     InterQueryThreadPool inter_query_threadpool_; // Handles parallelism across queries
-    const size_t intra_query_thread_count_;       // Number of threads per query processing
+    size_t intra_query_thread_count_;             // Number of threads per query processing
     mutable std::vector<IntraQueryThreadPool>
         intra_query_threadpools_; // Per-query parallel cluster exploration
 

--- a/include/svs/orchestrators/dynamic_ivf.h
+++ b/include/svs/orchestrators/dynamic_ivf.h
@@ -190,6 +190,14 @@ class DynamicIVF : public manager::IndexManager<DynamicIVFInterface> {
         return impl_->experimental_backend_string();
     }
 
+    // Intra-query (cluster-level) threading
+    size_t get_num_intra_query_threads() const {
+        return impl_->get_num_intra_query_threads();
+    }
+    void set_num_intra_query_threads(size_t count) {
+        impl_->set_num_intra_query_threads(count);
+    }
+
     // ID Inspection
 
     ///

--- a/include/svs/orchestrators/ivf.h
+++ b/include/svs/orchestrators/ivf.h
@@ -29,6 +29,10 @@ class IVFInterface {
     ///// Backend information interface
     virtual std::string experimental_backend_string() const = 0;
 
+    ///// Intra-query (cluster-level) parallelism
+    virtual size_t get_num_intra_query_threads() const = 0;
+    virtual void set_num_intra_query_threads(size_t count) = 0;
+
     ///// Distance calculation
     virtual double get_distance(size_t id, const AnonymousArray<1>& query) const = 0;
 
@@ -71,6 +75,14 @@ class IVFImpl : public manager::ManagerImpl<QueryTypes, Impl, IFace> {
     ///// Backend Information Interface
     [[nodiscard]] std::string experimental_backend_string() const override {
         return std::string{typename_impl.begin(), typename_impl.end() - 1};
+    }
+
+    ///// Intra-query (cluster-level) parallelism
+    [[nodiscard]] size_t get_num_intra_query_threads() const override {
+        return impl().get_num_intra_query_threads();
+    }
+    void set_num_intra_query_threads(size_t count) override {
+        impl().set_num_intra_query_threads(count);
     }
 
     ///// Distance Calculation
@@ -144,6 +156,14 @@ class IVF : public manager::IndexManager<IVFInterface> {
     ///// Backend String
     std::string experimental_backend_string() const {
         return impl_->experimental_backend_string();
+    }
+
+    ///// Intra-query (cluster-level) threading
+    size_t get_num_intra_query_threads() const {
+        return impl_->get_num_intra_query_threads();
+    }
+    void set_num_intra_query_threads(size_t count) {
+        impl_->set_num_intra_query_threads(count);
     }
 
     ///// Distance Calculation


### PR DESCRIPTION
Brings two FAISS-required runtime features to the IVF C++ bindings:

`IDFilter`-based search to support `SearchParameters::sel` selectors in `IndexSVSIVF`.
The ability to change the intra-query thread count after `train()` / `load()` (mirrors Vamana).