### PR TITLE
Fix duplicate-cluster trigger to require >=2 kept candidates

### DIFF
--- a/include/svs/index/vamana/prune.h
+++ b/include/svs/index/vamana/prune.h
@@ -185,8 +185,12 @@ void heuristic_prune_neighbors(
         current_alpha *= alpha;
     }
 
-    // Add a diversity edge if a duplicate cluster is detected
-    if (all_duplicates && anchor_set && !result.empty()) {
+    // Add a diversity edge if a duplicate cluster is detected.
+    // A "cluster" requires at least 2 kept candidates sharing the same
+    // distance; a single retained neighbor is not a cluster and must not
+    // be replaced (doing so would discard the only true nearest-neighbor
+    // edge for that node).
+    if (all_duplicates && anchor_set && result.size() >= 2) {
         auto result_id = [](const I& r) -> size_t {
             if constexpr (std::integral<I>) {
                 return static_cast<size_t>(r);
@@ -297,8 +301,12 @@ void heuristic_prune_neighbors(
         current_alpha *= alpha;
     }
 
-    // Add a diversity edge if a duplicate cluster is detected
-    if (all_duplicates && anchor_set && !result.empty()) {
+    // Add a diversity edge if a duplicate cluster is detected.
+    // A "cluster" requires at least 2 kept candidates sharing the same
+    // distance; a single retained neighbor is not a cluster and must not
+    // be replaced (doing so would discard the only true nearest-neighbor
+    // edge for that node).
+    if (all_duplicates && anchor_set && result.size() >= 2) {
         auto result_id = [](const I& r) -> size_t {
             if constexpr (std::integral<I>) {
                 return static_cast<size_t>(r);


### PR DESCRIPTION


PR #282 added a post-prune diversity step that fires when "all kept neighbors share the same distance". The original guard `!result.empty()` is also satisfied by `result.size() == 1`, because `all_duplicates` stays trivially true when only one candidate has been pushed into `result`. This causes the branch to fire on nodes whose alpha-pruning has collapsed `result` to a single retained neighbor, replacing that sole nearest-neighbor edge with a longer "diversity" edge -- which is unrelated to duplicate clusters.

Restrict the trigger to `result.size() >= 2` so it only activates when two or more retained candidates actually share the same distance, matching the intent described in PR #282 / issue #80.