### PR TITLE
Add primary-only LeanVec storage kinds to C++ runtime

### DIFF
--- a/bindings/cpp/include/svs/runtime/api_defs.h
+++ b/bindings/cpp/include/svs/runtime/api_defs.h
@@ -106,6 +106,10 @@ enum class StorageKind {
     LeanVec4x4,
     LeanVec4x8,
     LeanVec8x8,
+    // Primary-only LeanVec variants: only the lossy primary tier is stored, no
+    // secondary (reranking) tier. Trades reranking accuracy for ~50% less memory.
+    LeanVecLVQ4PrimaryOnly,
+    LeanVecLVQ8PrimaryOnly,
 };
 
 enum class ErrorCode {

--- a/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
+++ b/bindings/cpp/src/dynamic_vamana_index_leanvec_impl.h
@@ -95,6 +95,18 @@ struct DynamicVamanaIndexLeanVecImpl : public DynamicVamanaIndexImpl {
                     storage::StorageType<StorageKind::LeanVec8x8, allocator_type>{},
                     std::forward<Args>(args)...
                 );
+            case StorageKind::LeanVecLVQ4PrimaryOnly:
+                return f(
+                    storage::
+                        StorageType<StorageKind::LeanVecLVQ4PrimaryOnly, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
+            case StorageKind::LeanVecLVQ8PrimaryOnly:
+                return f(
+                    storage::
+                        StorageType<StorageKind::LeanVecLVQ8PrimaryOnly, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
             default:
                 throw StatusException{
                     ErrorCode::INVALID_ARGUMENT, "SVS LeanVec storage kind required"};

--- a/bindings/cpp/src/svs_runtime_utils.h
+++ b/bindings/cpp/src/svs_runtime_utils.h
@@ -114,7 +114,8 @@ inline constexpr bool is_lvq_storage(StorageKind kind) {
 
 inline constexpr bool is_leanvec_storage(StorageKind kind) {
     return kind == StorageKind::LeanVec4x4 || kind == StorageKind::LeanVec4x8 ||
-           kind == StorageKind::LeanVec8x8;
+           kind == StorageKind::LeanVec8x8 || kind == StorageKind::LeanVecLVQ4PrimaryOnly ||
+           kind == StorageKind::LeanVecLVQ8PrimaryOnly;
 }
 
 inline bool is_supported_storage_kind(StorageKind kind) {
@@ -344,6 +345,24 @@ template <typename Alloc> struct StorageType<StorageKind::LeanVec8x8, Alloc> {
     using type = LeanDatasetType<8, 8, allocator_type>;
 };
 
+// Primary-only LeanVec: secondary tier type is `void`.
+template <
+    size_t I1,
+    typename Alloc,
+    size_t LeanVecDims = svs::Dynamic,
+    size_t Extent = svs::Dynamic>
+using LeanDatasetPrimaryOnlyType =
+    svs::leanvec::LeanDataset<svs::leanvec::UsingLVQ<I1>, void, LeanVecDims, Extent, Alloc>;
+
+template <typename Alloc> struct StorageType<StorageKind::LeanVecLVQ4PrimaryOnly, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LeanDatasetPrimaryOnlyType<4, allocator_type>;
+};
+template <typename Alloc> struct StorageType<StorageKind::LeanVecLVQ8PrimaryOnly, Alloc> {
+    using allocator_type = rebind_extracted_allocator_t<std::byte, Alloc>;
+    using type = LeanDatasetPrimaryOnlyType<8, allocator_type>;
+};
+
 template <svs::leanvec::IsLeanDataset LeanVecStorageType>
 struct StorageFactory<LeanVecStorageType> {
     using StorageType = LeanVecStorageType;
@@ -394,6 +413,8 @@ auto dispatch_storage_kind(StorageKind kind, F&& f, Args&&... args) {
         SVS_DISPATCH_STORAGE_KIND(LeanVec4x4);
         SVS_DISPATCH_STORAGE_KIND(LeanVec4x8);
         SVS_DISPATCH_STORAGE_KIND(LeanVec8x8);
+        SVS_DISPATCH_STORAGE_KIND(LeanVecLVQ4PrimaryOnly);
+        SVS_DISPATCH_STORAGE_KIND(LeanVecLVQ8PrimaryOnly);
         default:
             throw StatusException(
                 ErrorCode::INVALID_ARGUMENT, "Unknown or unsupported SVS storage kind"

--- a/bindings/cpp/src/vamana_index_impl.h
+++ b/bindings/cpp/src/vamana_index_impl.h
@@ -555,6 +555,18 @@ struct VamanaIndexLeanVecImpl : public VamanaIndexImpl {
                     storage::StorageType<StorageKind::LeanVec8x8, allocator_type>{},
                     std::forward<Args>(args)...
                 );
+            case StorageKind::LeanVecLVQ4PrimaryOnly:
+                return f(
+                    storage::
+                        StorageType<StorageKind::LeanVecLVQ4PrimaryOnly, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
+            case StorageKind::LeanVecLVQ8PrimaryOnly:
+                return f(
+                    storage::
+                        StorageType<StorageKind::LeanVecLVQ8PrimaryOnly, allocator_type>{},
+                    std::forward<Args>(args)...
+                );
             default:
                 throw StatusException{
                     ErrorCode::INVALID_ARGUMENT, "SVS LeanVec storage kind required"};

--- a/bindings/cpp/tests/runtime_test.cpp
+++ b/bindings/cpp/tests/runtime_test.cpp
@@ -333,6 +333,56 @@ CATCH_TEST_CASE("WriteAndReadIndexSVSVamanaLeanVec4x4", "[runtime]") {
     );
 }
 
+CATCH_TEST_CASE("WriteAndReadIndexSVSVamanaLeanVecLVQ4PrimaryOnly", "[runtime]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::DynamicVamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        svs::runtime::v0::VamanaIndex::DynamicIndexParams dynamic_index_params{19};
+        return svs::runtime::v0::DynamicVamanaIndexLeanVec::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LeanVecLVQ4PrimaryOnly,
+            32,
+            build_params,
+            {},
+            dynamic_index_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::DynamicVamanaIndex>(
+        build_func,
+        test_data,
+        test_n,
+        test_d,
+        svs::runtime::v0::StorageKind::LeanVecLVQ4PrimaryOnly
+    );
+}
+
+CATCH_TEST_CASE("WriteAndReadIndexSVSVamanaLeanVecLVQ8PrimaryOnly", "[runtime]") {
+    const auto& test_data = get_test_data();
+    auto build_func = [](svs::runtime::v0::DynamicVamanaIndex** index) {
+        svs::runtime::v0::VamanaIndex::BuildParams build_params{64};
+        svs::runtime::v0::VamanaIndex::DynamicIndexParams dynamic_index_params{19};
+        return svs::runtime::v0::DynamicVamanaIndexLeanVec::build(
+            index,
+            test_d,
+            svs::runtime::v0::MetricType::L2,
+            svs::runtime::v0::StorageKind::LeanVecLVQ8PrimaryOnly,
+            32,
+            build_params,
+            {},
+            dynamic_index_params
+        );
+    };
+    write_and_read_index<svs::runtime::v0::DynamicVamanaIndex>(
+        build_func,
+        test_data,
+        test_n,
+        test_d,
+        svs::runtime::v0::StorageKind::LeanVecLVQ8PrimaryOnly
+    );
+}
+
 CATCH_TEST_CASE("LeanVecWithTrainingData", "[runtime]") {
     const auto& test_data = get_test_data();
     // Build LeanVec index with explicit training


### PR DESCRIPTION
> Supersedes #323 (which couldn't be reopened via API after force-push).

## Summary

Adds the **public C++ runtime surface** for primary-only LeanVec. This is the public-side counterpart to the private re-architecture; see the private PR for the design discussion and rationale.

## Changes

- `StorageKind` enum: two new variants `LeanVecLVQ4PrimaryOnly` and `LeanVecLVQ8PrimaryOnly`.
- `is_leanvec_storage()`: updated to recognize them.
- `LeanDatasetType` alias + `StorageType` specializations: produce `LeanDataset<UsingLVQ<N>, void, ...>` for the new kinds (mapping to the private partial specialization).
- `StorageFactory` specializations: build/load the primary-only LeanDataset (no secondary tier).
- `SVS_DISPATCH_STORAGE_KIND` macro: add both new cases to the dispatch.

## Architectural alignment

The private side now uses a partial specialization `LeanDataset<T1, void, ...>` (no runtime flag, no secondary member, no secondary methods) — mirroring how LVQ has separate one-level vs two-level classes. The public side exposes this through new `StorageKind` enum values, which is the same way LVQ4/LVQ8 variants are already exposed.

## Diff

+100 / −1 across 5 files. All additive at the public surface: no existing enum values changed, no existing API signatures changed.
