### PR TITLE
spinlock.h: add powerpc* support

### DIFF
--- a/include/svs/lib/spinlock.h
+++ b/include/svs/lib/spinlock.h
@@ -24,6 +24,8 @@ namespace detail {
 inline void pause() {
 #if defined(__i386__) || defined(__x86_64__)
     __builtin_ia32_pause();
+#elif defined(__powerpc__)
+    asm volatile("or 27,27,27" ::: "memory");
 #else //  __aarch64__
     asm volatile("yield" ::: "memory");
 #endif


### PR DESCRIPTION
This is the only change needed for powerpc* support. Tested on powerpc64le.