### PR TITLE
bump clang version to be compatible with macos-latest

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -36,10 +36,10 @@ jobs:
     strategy:
       matrix:
         build_type: [RelWithDebugInfo]
-        cxx: [clang++-15]
+        cxx: [clang++-20]
         include:
-        - cxx: clang++-15
-          package: llvm@15
+        - cxx: clang++-20
+          package: llvm@20
           cc_name: clang
           cxx_name: clang++
           needs_prefix: true


### PR DESCRIPTION
Latest macos github actions image was bumped and no longer supports specified clang versions. This is because we take latest: https://github.com/intel/ScalableVectorSearch/blob/main/.github/workflows/build-macos.yaml#L35 and as far as I can tell there is not an easy way to track this via dependabot. Alternative would be to pin it to a version but then it could sit idle and forgotten.