### PR TITLE
Refactor Blocked class to meet allocator requirements

### DIFF
--- a/include/svs/core/data/simple.h
+++ b/include/svs/core/data/simple.h
@@ -648,31 +648,32 @@ struct BlockingParameters {
     std::optional<lib::PowerOfTwo> blocksize_elements = std::nullopt;
 };
 
-template <typename Alloc> class Blocked {
+template <typename Alloc> class Blocked : public Alloc {
   public:
     using allocator_type = Alloc;
-    const allocator_type& get_allocator() const { return allocator_; }
+    using value_type = typename std::allocator_traits<allocator_type>::value_type;
+    const allocator_type& get_allocator() const { return *this; }
     const BlockingParameters& parameters() const { return parameters_; }
 
     constexpr Blocked() = default;
     explicit Blocked(const allocator_type& alloc)
-        : allocator_{alloc} {}
+        : allocator_type{alloc} {}
     explicit Blocked(const BlockingParameters& parameters)
-        : parameters_{parameters} {}
+        : allocator_type{}
+        , parameters_{parameters} {}
     explicit Blocked(const BlockingParameters& parameters, const allocator_type& alloc)
-        : parameters_{parameters}
-        , allocator_{alloc} {}
+        : allocator_type{alloc}
+        , parameters_{parameters} {}
 
     // Enable rebinding of allocators.
     template <typename U> friend class Blocked;
     template <typename U>
     Blocked(const Blocked<U>& other)
-        : parameters_{other.parameters_}
-        , allocator_{other.allocator_} {}
+        : allocator_type{other.get_allocator()}
+        , parameters_{other.parameters_} {}
 
   private:
     BlockingParameters parameters_{};
-    Alloc allocator_{};
 };
 
 template <typename Alloc> inline constexpr bool is_blocked_v = false;

--- a/tests/svs/core/data/block.cpp
+++ b/tests/svs/core/data/block.cpp
@@ -197,10 +197,18 @@ CATCH_TEST_CASE("Testing Blocked Data", "[core][data][blocked]") {
     }
 
     CATCH_SECTION("Blocked Allocator") {
-        // Use an integer for the "allocator" to test value propagation.
+        // Use a simple integer-valued struct for the "allocator" to test value propagation.
         // Since the `Blocked` class doesn't actually use the allocator, this is okay
         // for functionality testing.
-        using T = svs::data::Blocked<int>;
+        struct I {
+            using value_type = int;
+            int value;
+            I(int v = 0)
+                : value(v) {}
+            operator int() const { return value; }
+        };
+
+        using T = svs::data::Blocked<I>;
         using P = svs::data::BlockingParameters;
         auto x = T();
         CATCH_REQUIRE(x.get_allocator() == 0); // Default constructed integer.


### PR DESCRIPTION
This pull request refactors the `Blocked` class template to inherit from its allocator type instead of storing it as a member, and updates the associated test to use a struct-based allocator. This change simplifies allocator handling and improves compatibility with standard allocator patterns.

**Core class refactoring:**

* `Blocked` now inherits from its allocator type (`Alloc`) instead of storing an `Alloc allocator_` member, which simplifies construction, copying, and access to the allocator. The `get_allocator()` method now returns `*this` (as an allocator), and constructors have been updated accordingly.

**Test improvements:**

* The test for `Blocked` with an allocator has been updated to use a struct-based allocator (`I`), which provides a `value_type` and integer value for testing propagation and compatibility with the new inheritance-based implementation.