### PR TITLE
[C API] Add memory accounting (get_memory_usage / get_memory_breakdown)

### DIFF
--- a/bindings/c/include/svs/c_api/svs_c.h
+++ b/bindings/c/include/svs/c_api/svs_c.h
@@ -97,6 +97,13 @@ struct svs_search_results {
     float* distances;          /// Distances to the nearest neighbors
 };
 
+/// @brief Structure to hold memory breakdown for an index
+struct svs_memory_breakdown {
+    size_t graph_bytes;    /// Allocated bytes for the graph structure
+    size_t data_bytes;     /// Allocated bytes for the data vectors
+    size_t metadata_bytes; /// Allocated bytes for metadata (entry points, status, etc.)
+};
+
 // Handle typedefs; "_h" suffix indicates a handle to an opaque struct
 typedef struct svs_error_desc* svs_error_h;
 typedef struct svs_index* svs_index_h;
@@ -114,6 +121,7 @@ typedef enum svs_threadpool_kind svs_threadpool_kind_t;
 
 typedef struct svs_threadpool_interface* svs_threadpool_i;
 typedef struct svs_search_results* svs_search_results_t;
+typedef struct svs_memory_breakdown svs_memory_breakdown_t;
 
 /// @brief Create an error handle
 /// @return A handle to the created error object
@@ -526,6 +534,37 @@ SVS_API bool svs_index_get_num_threads(
 /// - SVS_ERROR_RUNTIME for other runtime failures
 SVS_API bool svs_index_set_num_threads(
     svs_index_h index, size_t num_threads, svs_error_h out_err /*=NULL*/
+);
+
+/// @brief Get the element size (bytes per vector) for the index
+/// @param index The index handle
+/// @param out_bytes Pointer to store the element size in bytes
+/// @param out_err An optional error handle to capture errors
+/// @return true on success, false on failure
+SVS_API bool svs_index_element_size(
+    svs_index_h index, size_t* out_bytes, svs_error_h out_err /*=NULL*/
+);
+
+/// @brief Get the total memory usage of the index in bytes
+/// @param index The index handle
+/// @param out_bytes Pointer to store the total memory usage in bytes
+/// @param out_err An optional error handle to capture errors
+/// @return true on success, false on failure
+/// @remarks This returns the sum of graph_bytes + data_bytes + metadata_bytes
+SVS_API bool svs_index_get_memory_usage(
+    svs_index_h index, size_t* out_bytes, svs_error_h out_err /*=NULL*/
+);
+
+/// @brief Get the memory breakdown for the index
+/// @param index The index handle
+/// @param out_breakdown Pointer to store the memory breakdown structure
+/// @param out_err An optional error handle to capture errors
+/// @return true on success, false on failure
+/// @remarks The breakdown reports allocated memory for graph, data, and metadata
+/// components. Uses capacity-based accounting for datasets that support it, reflecting
+/// the true memory footprint including over-allocation.
+SVS_API bool svs_index_get_memory_breakdown(
+    svs_index_h index, svs_memory_breakdown_t* out_breakdown, svs_error_h out_err /*=NULL*/
 );
 
 #ifdef __cplusplus

--- a/bindings/c/include/svs/c_api/svs_c.h
+++ b/bindings/c/include/svs/c_api/svs_c.h
@@ -536,15 +536,6 @@ SVS_API bool svs_index_set_num_threads(
     svs_index_h index, size_t num_threads, svs_error_h out_err /*=NULL*/
 );
 
-/// @brief Get the element size (bytes per vector) for the index
-/// @param index The index handle
-/// @param out_bytes Pointer to store the element size in bytes
-/// @param out_err An optional error handle to capture errors
-/// @return true on success, false on failure
-SVS_API bool svs_index_element_size(
-    svs_index_h index, size_t* out_bytes, svs_error_h out_err /*=NULL*/
-);
-
 /// @brief Get the total memory usage of the index in bytes
 /// @param index The index handle
 /// @param out_bytes Pointer to store the total memory usage in bytes

--- a/bindings/c/src/index.hpp
+++ b/bindings/c/src/index.hpp
@@ -52,7 +52,6 @@ struct Index {
     reconstruct_at(svs::data::SimpleDataView<float> dst, std::span<const size_t> ids) = 0;
     virtual size_t get_num_threads() const = 0;
     virtual void set_num_threads(size_t num_threads) = 0;
-    virtual size_t element_size() const = 0;
     virtual svs::index::vamana::MemoryBreakdown get_memory_breakdown() const = 0;
 };
 
@@ -115,8 +114,6 @@ struct IndexVamana : public Index {
         pool_builder.resize(num_threads);
         index.set_threadpool(pool_builder.build());
     }
-
-    size_t element_size() const override { return index.element_size(); }
 
     svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
         return index.get_memory_breakdown();
@@ -207,8 +204,6 @@ struct DynamicIndexVamana : public DynamicIndex {
         pool_builder.resize(num_threads);
         index.set_threadpool(pool_builder.build());
     }
-
-    size_t element_size() const override { return index.element_size(); }
 
     svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
         return index.get_memory_breakdown();

--- a/bindings/c/src/index.hpp
+++ b/bindings/c/src/index.hpp
@@ -52,6 +52,8 @@ struct Index {
     reconstruct_at(svs::data::SimpleDataView<float> dst, std::span<const size_t> ids) = 0;
     virtual size_t get_num_threads() const = 0;
     virtual void set_num_threads(size_t num_threads) = 0;
+    virtual size_t element_size() const = 0;
+    virtual svs::index::vamana::MemoryBreakdown get_memory_breakdown() const = 0;
 };
 
 struct DynamicIndex : public Index {
@@ -112,6 +114,12 @@ struct IndexVamana : public Index {
     void set_num_threads(size_t num_threads) override {
         pool_builder.resize(num_threads);
         index.set_threadpool(pool_builder.build());
+    }
+
+    size_t element_size() const override { return index.element_size(); }
+
+    svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
+        return index.get_memory_breakdown();
     }
 };
 
@@ -198,6 +206,12 @@ struct DynamicIndexVamana : public DynamicIndex {
     void set_num_threads(size_t num_threads) override {
         pool_builder.resize(num_threads);
         index.set_threadpool(pool_builder.build());
+    }
+
+    size_t element_size() const override { return index.element_size(); }
+
+    svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
+        return index.get_memory_breakdown();
     }
 };
 } // namespace svs::c_runtime

--- a/bindings/c/src/svs_c.cpp
+++ b/bindings/c/src/svs_c.cpp
@@ -823,23 +823,6 @@ svs_index_set_num_threads(svs_index_h index, size_t num_threads, svs_error_h out
 }
 
 extern "C" bool
-svs_index_element_size(svs_index_h index, size_t* out_bytes, svs_error_h out_err) {
-    using namespace svs::c_runtime;
-    return wrap_exceptions(
-        [&]() {
-            EXPECT_ARG_NOT_NULL(index);
-            EXPECT_ARG_NOT_NULL(out_bytes);
-            auto& index_ptr = index->impl;
-            INVALID_ARGUMENT_IF(index_ptr == nullptr, "Invalid index handle");
-            *out_bytes = index_ptr->element_size();
-            return true;
-        },
-        out_err,
-        false
-    );
-}
-
-extern "C" bool
 svs_index_get_memory_usage(svs_index_h index, size_t* out_bytes, svs_error_h out_err) {
     using namespace svs::c_runtime;
     return wrap_exceptions(

--- a/bindings/c/src/svs_c.cpp
+++ b/bindings/c/src/svs_c.cpp
@@ -821,3 +821,59 @@ svs_index_set_num_threads(svs_index_h index, size_t num_threads, svs_error_h out
         false
     );
 }
+
+extern "C" bool
+svs_index_element_size(svs_index_h index, size_t* out_bytes, svs_error_h out_err) {
+    using namespace svs::c_runtime;
+    return wrap_exceptions(
+        [&]() {
+            EXPECT_ARG_NOT_NULL(index);
+            EXPECT_ARG_NOT_NULL(out_bytes);
+            auto& index_ptr = index->impl;
+            INVALID_ARGUMENT_IF(index_ptr == nullptr, "Invalid index handle");
+            *out_bytes = index_ptr->element_size();
+            return true;
+        },
+        out_err,
+        false
+    );
+}
+
+extern "C" bool
+svs_index_get_memory_usage(svs_index_h index, size_t* out_bytes, svs_error_h out_err) {
+    using namespace svs::c_runtime;
+    return wrap_exceptions(
+        [&]() {
+            EXPECT_ARG_NOT_NULL(index);
+            EXPECT_ARG_NOT_NULL(out_bytes);
+            auto& index_ptr = index->impl;
+            INVALID_ARGUMENT_IF(index_ptr == nullptr, "Invalid index handle");
+            auto breakdown = index_ptr->get_memory_breakdown();
+            *out_bytes = breakdown.total();
+            return true;
+        },
+        out_err,
+        false
+    );
+}
+
+extern "C" bool svs_index_get_memory_breakdown(
+    svs_index_h index, svs_memory_breakdown_t* out_breakdown, svs_error_h out_err
+) {
+    using namespace svs::c_runtime;
+    return wrap_exceptions(
+        [&]() {
+            EXPECT_ARG_NOT_NULL(index);
+            EXPECT_ARG_NOT_NULL(out_breakdown);
+            auto& index_ptr = index->impl;
+            INVALID_ARGUMENT_IF(index_ptr == nullptr, "Invalid index handle");
+            auto breakdown = index_ptr->get_memory_breakdown();
+            out_breakdown->graph_bytes = breakdown.graph_bytes;
+            out_breakdown->data_bytes = breakdown.data_bytes;
+            out_breakdown->metadata_bytes = breakdown.metadata_bytes;
+            return true;
+        },
+        out_err,
+        false
+    );
+}

--- a/bindings/c/tests/c_api_dynamic_index.cpp
+++ b/bindings/c/tests/c_api_dynamic_index.cpp
@@ -368,7 +368,8 @@ CATCH_TEST_CASE("C API Dynamic Index", "[c_api][index][dynamic]") {
         CATCH_REQUIRE(success);
         CATCH_REQUIRE(svs_error_ok(error));
         CATCH_REQUIRE(element_size > 0);
-        CATCH_REQUIRE(element_size == DIMENSION * sizeof(float));
+        // element_size now returns data + graph adjacency row (per-vector bytes)
+        CATCH_REQUIRE(element_size > DIMENSION * sizeof(float));
 
         // Test get_memory_usage
         size_t memory_usage = 0;

--- a/bindings/c/tests/c_api_dynamic_index.cpp
+++ b/bindings/c/tests/c_api_dynamic_index.cpp
@@ -362,15 +362,6 @@ CATCH_TEST_CASE("C API Dynamic Index", "[c_api][index][dynamic]") {
         CATCH_REQUIRE(index != nullptr);
         CATCH_REQUIRE(svs_error_ok(error));
 
-        // Test element_size
-        size_t element_size = 0;
-        bool success = svs_index_element_size(index, &element_size, error);
-        CATCH_REQUIRE(success);
-        CATCH_REQUIRE(svs_error_ok(error));
-        CATCH_REQUIRE(element_size > 0);
-        // element_size now returns data + graph adjacency row (per-vector bytes)
-        CATCH_REQUIRE(element_size > DIMENSION * sizeof(float));
-
         // Test get_memory_usage
         size_t memory_usage = 0;
         success = svs_index_get_memory_usage(index, &memory_usage, error);

--- a/bindings/c/tests/c_api_dynamic_index.cpp
+++ b/bindings/c/tests/c_api_dynamic_index.cpp
@@ -354,6 +354,46 @@ CATCH_TEST_CASE("C API Dynamic Index", "[c_api][index][dynamic]") {
         svs_index_free(index);
     }
 
+    CATCH_SECTION("Memory Accounting Functions") {
+        // Build dynamic index
+        svs_index_h index = svs_index_build_dynamic(
+            builder, data.data(), ids.data(), NUM_VECTORS, BLOCK_SIZE, error
+        );
+        CATCH_REQUIRE(index != nullptr);
+        CATCH_REQUIRE(svs_error_ok(error));
+
+        // Test element_size
+        size_t element_size = 0;
+        bool success = svs_index_element_size(index, &element_size, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(element_size > 0);
+        CATCH_REQUIRE(element_size == DIMENSION * sizeof(float));
+
+        // Test get_memory_usage
+        size_t memory_usage = 0;
+        success = svs_index_get_memory_usage(index, &memory_usage, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(memory_usage > 0);
+
+        // Test get_memory_breakdown
+        svs_memory_breakdown_t breakdown;
+        success = svs_index_get_memory_breakdown(index, &breakdown, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(breakdown.graph_bytes > 0);
+        CATCH_REQUIRE(breakdown.data_bytes > 0);
+        CATCH_REQUIRE(breakdown.metadata_bytes > 0);
+
+        // Verify that breakdown.total() == memory_usage
+        size_t total =
+            breakdown.graph_bytes + breakdown.data_bytes + breakdown.metadata_bytes;
+        CATCH_REQUIRE(total == memory_usage);
+
+        svs_index_free(index);
+    }
+
     svs_index_builder_free(builder);
     svs_algorithm_free(algorithm);
     svs_error_free(error);

--- a/bindings/c/tests/c_api_index.cpp
+++ b/bindings/c/tests/c_api_index.cpp
@@ -746,8 +746,8 @@ CATCH_TEST_CASE("C API Threadpool Management", "[c_api][index][threadpool]") {
         CATCH_REQUIRE(success);
         CATCH_REQUIRE(svs_error_ok(error));
         CATCH_REQUIRE(element_size > 0);
-        // For float32 with 32 dimensions, element_size should be 32 * sizeof(float) = 128
-        CATCH_REQUIRE(element_size == DIMENSION * sizeof(float));
+        // element_size now returns data + graph adjacency row (per-vector bytes)
+        CATCH_REQUIRE(element_size > DIMENSION * sizeof(float));
 
         // Test get_memory_usage
         size_t memory_usage = 0;

--- a/bindings/c/tests/c_api_index.cpp
+++ b/bindings/c/tests/c_api_index.cpp
@@ -740,15 +740,6 @@ CATCH_TEST_CASE("C API Threadpool Management", "[c_api][index][threadpool]") {
         CATCH_REQUIRE(index != nullptr);
         CATCH_REQUIRE(svs_error_ok(error));
 
-        // Test element_size
-        size_t element_size = 0;
-        success = svs_index_element_size(index, &element_size, error);
-        CATCH_REQUIRE(success);
-        CATCH_REQUIRE(svs_error_ok(error));
-        CATCH_REQUIRE(element_size > 0);
-        // element_size now returns data + graph adjacency row (per-vector bytes)
-        CATCH_REQUIRE(element_size > DIMENSION * sizeof(float));
-
         // Test get_memory_usage
         size_t memory_usage = 0;
         success = svs_index_get_memory_usage(index, &memory_usage, error);
@@ -770,20 +761,8 @@ CATCH_TEST_CASE("C API Threadpool Management", "[c_api][index][threadpool]") {
             breakdown.graph_bytes + breakdown.data_bytes + breakdown.metadata_bytes;
         CATCH_REQUIRE(total == memory_usage);
 
-        // Test null-arg handling for element_size
-        svs_error_h error2 = svs_error_create();
-        success = svs_index_element_size(nullptr, &element_size, error2);
-        CATCH_REQUIRE(success == false);
-        CATCH_REQUIRE(svs_error_ok(error2) == false);
-        svs_error_free(error2);
-
-        error2 = svs_error_create();
-        success = svs_index_element_size(index, nullptr, error2);
-        CATCH_REQUIRE(success == false);
-        svs_error_free(error2);
-
         // Test null-arg handling for get_memory_usage
-        error2 = svs_error_create();
+        svs_error_h error2 = svs_error_create();
         success = svs_index_get_memory_usage(nullptr, &memory_usage, error2);
         CATCH_REQUIRE(success == false);
         svs_error_free(error2);

--- a/bindings/c/tests/c_api_index.cpp
+++ b/bindings/c/tests/c_api_index.cpp
@@ -714,4 +714,99 @@ CATCH_TEST_CASE("C API Threadpool Management", "[c_api][index][threadpool]") {
         svs_algorithm_free(algorithm);
         svs_error_free(error);
     }
+
+    CATCH_SECTION("Memory Accounting Functions") {
+        svs_error_h error = svs_error_create();
+
+        // Create algorithm
+        svs_algorithm_h algorithm = svs_algorithm_create_vamana(16, 32, 50, error);
+        CATCH_REQUIRE(algorithm != nullptr);
+        CATCH_REQUIRE(svs_error_ok(error));
+
+        // Create builder
+        svs_index_builder_h builder = svs_index_builder_create(
+            SVS_DISTANCE_METRIC_EUCLIDEAN, DIMENSION, algorithm, error
+        );
+        CATCH_REQUIRE(builder != nullptr);
+        CATCH_REQUIRE(svs_error_ok(error));
+
+        bool success =
+            svs_index_builder_set_threadpool(builder, SVS_THREADPOOL_KIND_NATIVE, 4, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+
+        // Build index
+        svs_index_h index = svs_index_build(builder, data.data(), NUM_VECTORS, error);
+        CATCH_REQUIRE(index != nullptr);
+        CATCH_REQUIRE(svs_error_ok(error));
+
+        // Test element_size
+        size_t element_size = 0;
+        success = svs_index_element_size(index, &element_size, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(element_size > 0);
+        // For float32 with 32 dimensions, element_size should be 32 * sizeof(float) = 128
+        CATCH_REQUIRE(element_size == DIMENSION * sizeof(float));
+
+        // Test get_memory_usage
+        size_t memory_usage = 0;
+        success = svs_index_get_memory_usage(index, &memory_usage, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(memory_usage > 0);
+
+        // Test get_memory_breakdown
+        svs_memory_breakdown_t breakdown;
+        success = svs_index_get_memory_breakdown(index, &breakdown, error);
+        CATCH_REQUIRE(success);
+        CATCH_REQUIRE(svs_error_ok(error));
+        CATCH_REQUIRE(breakdown.graph_bytes > 0);
+        CATCH_REQUIRE(breakdown.data_bytes > 0);
+        CATCH_REQUIRE(breakdown.metadata_bytes >= 0);
+
+        // Verify that breakdown.total() == memory_usage
+        size_t total =
+            breakdown.graph_bytes + breakdown.data_bytes + breakdown.metadata_bytes;
+        CATCH_REQUIRE(total == memory_usage);
+
+        // Test null-arg handling for element_size
+        svs_error_h error2 = svs_error_create();
+        success = svs_index_element_size(nullptr, &element_size, error2);
+        CATCH_REQUIRE(success == false);
+        CATCH_REQUIRE(svs_error_ok(error2) == false);
+        svs_error_free(error2);
+
+        error2 = svs_error_create();
+        success = svs_index_element_size(index, nullptr, error2);
+        CATCH_REQUIRE(success == false);
+        svs_error_free(error2);
+
+        // Test null-arg handling for get_memory_usage
+        error2 = svs_error_create();
+        success = svs_index_get_memory_usage(nullptr, &memory_usage, error2);
+        CATCH_REQUIRE(success == false);
+        svs_error_free(error2);
+
+        error2 = svs_error_create();
+        success = svs_index_get_memory_usage(index, nullptr, error2);
+        CATCH_REQUIRE(success == false);
+        svs_error_free(error2);
+
+        // Test null-arg handling for get_memory_breakdown
+        error2 = svs_error_create();
+        success = svs_index_get_memory_breakdown(nullptr, &breakdown, error2);
+        CATCH_REQUIRE(success == false);
+        svs_error_free(error2);
+
+        error2 = svs_error_create();
+        success = svs_index_get_memory_breakdown(index, nullptr, error2);
+        CATCH_REQUIRE(success == false);
+        svs_error_free(error2);
+
+        svs_index_free(index);
+        svs_index_builder_free(builder);
+        svs_algorithm_free(algorithm);
+        svs_error_free(error);
+    }
 }

--- a/include/svs/core/data.h
+++ b/include/svs/core/data.h
@@ -153,6 +153,22 @@ class VectorDataLoader {
 
 // Matching rule for uncompressed data.
 namespace data::detail {
+
+///
+/// @brief Return the allocated bytes for a dataset.
+///
+/// Capacity-based accounting for datasets that expose a ``capacity()`` accessor, so that
+/// block over-allocation is reflected. Datasets that do not expose ``capacity()`` fall
+/// back to the number of live elements.
+///
+template <typename Dataset> size_t dataset_allocated_bytes(const Dataset& dataset) {
+    if constexpr (requires(const Dataset& d) { d.capacity(); }) {
+        return dataset.capacity() * dataset.element_size();
+    } else {
+        return dataset.size() * dataset.element_size();
+    }
+}
+
 template <typename T, size_t Extent> int64_t check_match(svs::DataType type, size_t dims) {
     // If the types don't match - then there is no match.
     if (type != svs::datatype_v<T>) {

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -449,13 +449,6 @@ class MutableVamanaIndex {
     ///
     size_t dimensions() const { return data_.dimensions(); }
 
-    /// @brief Return the element size (bytes per vector) for the indexed data.
-    ///
-    /// Returns the per-vector memory footprint = dataset row + graph adjacency row.
-    size_t element_size() const {
-        return data_.element_size() + graph_.get_data().element_size();
-    }
-
     /// @brief Return memory breakdown for the index.
     ///
     /// Reports the allocated memory for graph, data, and metadata components. Uses

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -449,6 +449,35 @@ class MutableVamanaIndex {
     ///
     size_t dimensions() const { return data_.dimensions(); }
 
+    /// @brief Return the element size (bytes per vector) for the indexed data.
+    size_t element_size() const { return data_.element_size(); }
+
+    /// @brief Return memory breakdown for the index.
+    ///
+    /// Reports the allocated memory for graph, data, and metadata components. Uses
+    /// capacity-based accounting for datasets that expose ``capacity()``, so that block
+    /// over-allocation is reflected. Metadata includes status array, entry points, and an
+    /// estimated size of the ID translation maps (external/internal ID translation maps).
+    MemoryBreakdown get_memory_breakdown() const {
+        MemoryBreakdown usage{};
+        usage.graph_bytes = svs::data::detail::dataset_allocated_bytes(graph_.get_data());
+        usage.data_bytes = svs::data::detail::dataset_allocated_bytes(data_);
+
+        size_t metadata_bytes = status_.capacity() * sizeof(SlotMetadata);
+        metadata_bytes +=
+            entry_point_.capacity() * sizeof(typename entry_point_type::value_type);
+        // The IDTranslator holds two tsl::robin_map instances (external->internal and
+        // internal->external), neither of which exposes its allocated byte count. We
+        // approximate the storage as the id pair held in each of the two directions. This
+        // ignores the maps' load-factor slack and control bytes, so it is an estimate of
+        // the hash-map overhead that is accurate to within a few percent.
+        metadata_bytes += 2 * translator_.size() *
+                          (sizeof(IDTranslator::external_id_type) +
+                           sizeof(IDTranslator::internal_id_type));
+        usage.metadata_bytes = metadata_bytes;
+        return usage;
+    }
+
     // Return a `greedy_search` compatible builder for this index.
     // This is an internal method, mostly used to help implement the batch iterator.
     ValidBuilder internal_search_builder() const { return ValidBuilder{status_}; }

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -450,7 +450,11 @@ class MutableVamanaIndex {
     size_t dimensions() const { return data_.dimensions(); }
 
     /// @brief Return the element size (bytes per vector) for the indexed data.
-    size_t element_size() const { return data_.element_size(); }
+    ///
+    /// Returns the per-vector memory footprint = dataset row + graph adjacency row.
+    size_t element_size() const {
+        return data_.element_size() + graph_.get_data().element_size();
+    }
 
     /// @brief Return memory breakdown for the index.
     ///

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -625,7 +625,11 @@ class VamanaIndex {
     size_t dimensions() const { return data_.dimensions(); }
 
     /// @brief Return the element size (bytes per vector) for the indexed data.
-    size_t element_size() const { return data_.element_size(); }
+    ///
+    /// Returns the per-vector memory footprint = dataset row + graph adjacency row.
+    size_t element_size() const {
+        return data_.element_size() + graph_.get_data().element_size();
+    }
 
     /// @brief Return memory breakdown for the index.
     ///

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -624,13 +624,6 @@ class VamanaIndex {
     /// @brief Return the logical number aLf dimensions of the indexed vectors.
     size_t dimensions() const { return data_.dimensions(); }
 
-    /// @brief Return the element size (bytes per vector) for the indexed data.
-    ///
-    /// Returns the per-vector memory footprint = dataset row + graph adjacency row.
-    size_t element_size() const {
-        return data_.element_size() + graph_.get_data().element_size();
-    }
-
     /// @brief Return memory breakdown for the index.
     ///
     /// Reports the allocated memory for graph, data, and metadata components. Uses

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -178,6 +178,17 @@ struct VamanaIndexParameters {
 };
 
 ///
+/// @brief Memory breakdown for Vamana index.
+///
+struct MemoryBreakdown {
+    size_t graph_bytes = 0;
+    size_t data_bytes = 0;
+    size_t metadata_bytes = 0;
+
+    size_t total() const { return graph_bytes + data_bytes + metadata_bytes; }
+};
+
+///
 /// @brief Search scratchspace used by the Vamana index.
 ///
 /// These can be pre-allocated and passed to the index when performing externally
@@ -612,6 +623,24 @@ class VamanaIndex {
 
     /// @brief Return the logical number aLf dimensions of the indexed vectors.
     size_t dimensions() const { return data_.dimensions(); }
+
+    /// @brief Return the element size (bytes per vector) for the indexed data.
+    size_t element_size() const { return data_.element_size(); }
+
+    /// @brief Return memory breakdown for the index.
+    ///
+    /// Reports the allocated memory for graph, data, and metadata components. Uses
+    /// capacity-based accounting for datasets that expose ``capacity()``, so that block
+    /// over-allocation is reflected. Metadata includes entry points. Integrators can use
+    /// this to report the true memory footprint of the index.
+    MemoryBreakdown get_memory_breakdown() const {
+        MemoryBreakdown usage{};
+        usage.graph_bytes = svs::data::detail::dataset_allocated_bytes(graph_.get_data());
+        usage.data_bytes = svs::data::detail::dataset_allocated_bytes(data_);
+        usage.metadata_bytes =
+            entry_point_.capacity() * sizeof(typename entry_point_type::value_type);
+        return usage;
+    }
 
     /// @brief Reconstruct vectors.
     ///

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -262,6 +262,14 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         impl_->reconstruct_at(data, ids);
     }
 
+    /// @copydoc svs::index::vamana::MutableVamanaIndex::element_size
+    size_t element_size() const { return impl_->element_size(); }
+
+    /// @copydoc svs::index::vamana::MutableVamanaIndex::get_memory_breakdown
+    svs::index::vamana::MemoryBreakdown get_memory_breakdown() const {
+        return impl_->get_memory_breakdown();
+    }
+
     // Building
     ///
     /// @brief Construct a DynamicVamana index from a data loader or dataset.

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -262,9 +262,6 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         impl_->reconstruct_at(data, ids);
     }
 
-    /// @copydoc svs::index::vamana::MutableVamanaIndex::element_size
-    size_t element_size() const { return impl_->element_size(); }
-
     /// @copydoc svs::index::vamana::MutableVamanaIndex::get_memory_breakdown
     svs::index::vamana::MemoryBreakdown get_memory_breakdown() const {
         return impl_->get_memory_breakdown();

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -103,7 +103,6 @@ class VamanaInterface {
     virtual double get_distance(size_t id, const AnonymousArray<1>& query) const = 0;
 
     ///// Memory accounting
-    virtual size_t element_size() const = 0;
     virtual svs::index::vamana::MemoryBreakdown get_memory_breakdown() const = 0;
 };
 
@@ -272,8 +271,6 @@ class VamanaImpl : public manager::ManagerImpl<QueryTypes, Impl, IFace> {
         );
     }
 
-    size_t element_size() const override { return impl().element_size(); }
-
     svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
         return impl().get_memory_breakdown();
     }
@@ -389,9 +386,6 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     void reconstruct_at(data::SimpleDataView<float> data, std::span<const uint64_t> ids) {
         impl_->reconstruct_at(data, ids);
     }
-
-    /// @copydoc svs::index::vamana::VamanaIndex::element_size
-    size_t element_size() const { return impl_->element_size(); }
 
     /// @copydoc svs::index::vamana::VamanaIndex::get_memory_breakdown
     svs::index::vamana::MemoryBreakdown get_memory_breakdown() const {

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -101,6 +101,10 @@ class VamanaInterface {
 
     // Non-templated virtual method for distance calculation
     virtual double get_distance(size_t id, const AnonymousArray<1>& query) const = 0;
+
+    ///// Memory accounting
+    virtual size_t element_size() const = 0;
+    virtual svs::index::vamana::MemoryBreakdown get_memory_breakdown() const = 0;
 };
 
 template <lib::TypeList QueryTypes, typename Impl, typename IFace = VamanaInterface>
@@ -267,6 +271,12 @@ class VamanaImpl : public manager::ManagerImpl<QueryTypes, Impl, IFace> {
             }
         );
     }
+
+    size_t element_size() const override { return impl().element_size(); }
+
+    svs::index::vamana::MemoryBreakdown get_memory_breakdown() const override {
+        return impl().get_memory_breakdown();
+    }
 };
 
 ///// Forward declarations
@@ -378,6 +388,14 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
 
     void reconstruct_at(data::SimpleDataView<float> data, std::span<const uint64_t> ids) {
         impl_->reconstruct_at(data, ids);
+    }
+
+    /// @copydoc svs::index::vamana::VamanaIndex::element_size
+    size_t element_size() const { return impl_->element_size(); }
+
+    /// @copydoc svs::index::vamana::VamanaIndex::get_memory_breakdown
+    svs::index::vamana::MemoryBreakdown get_memory_breakdown() const {
+        return impl_->get_memory_breakdown();
     }
 
     ///


### PR DESCRIPTION
## Summary

Exposes memory accounting in the **C API** for the Valkey-search integration:

- `svs_index_get_memory_usage(index, size_t* out_bytes, err)` — total allocated bytes.
- `svs_index_get_memory_breakdown(index, svs_memory_breakdown_t* out, err)` — `{graph_bytes, data_bytes, metadata_bytes}` component split.
~~- `svs_index_element_size(index, size_t* out_bytes, err)` — bytes per stored vector.~~ (keep at data level)

All follow the existing C API conventions (out-param + `svs_error_h`, `wrap_exceptions`), matching the Phase-A design in the memory-accounting contract (intel-innersource #333).

## Layers

- **C API** (`bindings/c`): the three functions + `svs_memory_breakdown_t` in `svs_c.h`; interface virtuals + concrete overrides in `src/index.hpp`; impls in `src/svs_c.cpp`.
- **Core / orchestrator**: brings in `get_memory_breakdown()` (`MemoryBreakdown` struct + capacity-based `svs::data::detail::dataset_allocated_bytes` helper) on `VamanaIndex` / `MutableVamanaIndex` and through the orchestrator, plus an `element_size()` accessor parallel to `dimensions()`. This mirrors the approved public PR #345 so the C API can build and test standalone; once #345 lands on `dev/c-api`, this reduces to just the C API layer.

## Tests

`bindings/c/tests/c_api_index.cpp` (static) and `c_api_dynamic_index.cpp` (dynamic): usage > 0, breakdown total == usage, `graph_bytes`/`data_bytes` > 0 (metadata > 0 for dynamic), `element_size == sizeof(float) * dimensions`, and null-arg handling. Both test cases pass (84 / 166 assertions).

Related: builds on intel/ScalableVectorSearch#345; memory-accounting contract in intel-innersource #333 / #326.