### PR TITLE
Update SVS_URL to nightly with get_memory_breakdown

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -138,7 +138,7 @@ if (SVS_RUNTIME_ENABLE_LVQ_LEANVEC)
     else()
         # Links to LTO-enabled static library, requires GCC/G++ 11.2
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3")
-            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-05-21-1429.tar.gz"
+            set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-shared-library-lto-nightly-2026-07-21-127.tar.gz"
                 CACHE STRING "URL to download SVS shared library")
         else()
             message(WARNING


### PR DESCRIPTION
Bumps the pinned LTO prebuilt SVS library (`bindings/cpp/CMakeLists.txt`) from `svs-shared-library-lto-nightly-2026-05-21-1429` to `svs-shared-library-lto-nightly-2026-07-21-127`, which includes `get_memory_usage()` / `get_memory_breakdown()` (#345).

## Why

The `Build and unit tests for C++ runtime bindings (with static library, ON)` job links the runtime bindings against this prebuilt lib. The previously-pinned nightly predated #345, so it failed:

```
bindings/cpp/src/dynamic_vamana_index_impl.h:73: error: no member named 'get_memory_breakdown' in 'svs::DynamicVamana'
```

The new nightly was built from `main` (post-#345, via the private-repo submodule bump intel-innersource#338) and ships the method — verified the tarball's headers contain `get_memory_breakdown`. This should turn that CI job green.

Follows the pattern of #311 (Update SVS_URL in binaries).